### PR TITLE
Added support for custom filters at LDAP

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,6 +11,7 @@
 * Courier and PAM authentication methods
 * Git and SQL storages
 * CardDAV support
+* LDAP: custom filters supported
 
 
 0.6.4 - Tulips

--- a/config
+++ b/config
@@ -56,6 +56,11 @@ ldap_url = ldap://localhost:389/
 ldap_base = ou=users,dc=example,dc=com
 # LDAP login attribute
 ldap_attribute = uid
+# LDAP filter string
+# placed as X in a query of the form (&(...)X)
+# example: (objectCategory=Person)(objectClass=User)(memberOf=cn=calenderusers,ou=users,dc=example,dc=org)
+# leave empty if no additional filter is needed
+ldap_filter = 
 # LDAP dn for initial login, used if LDAP server does not allow anonymous searches
 # Leave empty if searches are anonymous
 ldap_binddn =

--- a/radicale/acl/LDAP.py
+++ b/radicale/acl/LDAP.py
@@ -31,6 +31,7 @@ from radicale import acl, config, log
 
 BASE = config.get("acl", "ldap_base")
 ATTRIBUTE = config.get("acl", "ldap_attribute")
+FILTER = config.get("acl", "ldap_filter")
 CONNEXION = ldap.initialize(config.get("acl", "ldap_url"))
 BINDDN = config.get("acl", "ldap_binddn")
 PASSWORD = config.get("acl", "ldap_password")
@@ -59,7 +60,13 @@ def has_right(owner, user, password):
     log.LOGGER.debug(
         "LDAP bind for %s in base %s" % (distinguished_name, BASE))
 
-    users = CONNEXION.search_s(BASE, SCOPE, distinguished_name)
+    if FILTER:
+        filterStr = "(&(%s)%s)" % (distinguished_name,FILTER)
+    else:
+        filterStr = distinguished_name
+    log.LOGGER.debug("Used LDAP filter: %s" % filterStr)
+
+    users = CONNEXION.search_s(BASE, SCOPE, filterStr)
     if users:
         log.LOGGER.debug("User %s found" % user)
         try:


### PR DESCRIPTION
We use explicit groups to sort our users. Therefore, we need additional LDAP filters for authentification. I added that functionality to radicale.
