### PR TITLE
Trailing slash problem

### DIFF
--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -208,7 +208,7 @@ class Collection(object):
         attributes = sane_path.split("/")
         if not attributes:
             return None
-        if not (cls.is_leaf("/".join(attributes)) or path.endswith("/")):
+        if not (cls.is_leaf("/".join(attributes)) or len(attributes) == 2):
             attributes.pop()
 
         result = []


### PR DESCRIPTION
I have been bugged by a little problem tonight which made me
investigate. Somehow, a calendar or contactbook only get's created if
the resource is retrieved WITH a trailing slash.

Example:

```
  http://<MYHOST>/vincent/calendar.ics
```

This won't create the not existing "calendar.ics"

```
  http://<MYHOST>/vincent/calendar.ics/
```

This will create the not yet existing "calendar.ics" but returns a 410
GONE error message.

In my opinion this is not desired behavior, especially because the
calendar.ics or contacts.vcf suggest that you are retrieving a file,
because of the extension.

This path will fix this problem
