### PR TITLE
Add locking functionality

### DIFF
--- a/config
+++ b/config
@@ -88,6 +88,10 @@ type = None
 # Storage backend
 type = filesystem
 
+# Enable locking. Requires the lockfile package installed
+# http://packages.python.org/lockfile/
+locking = False
+
 # Folder for storing local collections, created if not present
 filesystem_folder = ~/.config/radicale/collections
 

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -73,7 +73,8 @@ INITIAL_CONFIG = {
         "filesystem_folder": os.path.expanduser(
             "~/.config/radicale/collections"),
         "git_folder": os.path.expanduser(
-            "~/.config/radicale/collections")},
+            "~/.config/radicale/collections"),
+        "locking": "False"},
     "logging": {
         "config": "/etc/radicale/logging",
         "debug": "False",


### PR DESCRIPTION
This code adds the option locking to filesystem so  that consistent content of calendars is given. It uses an external package locking. If you're ok with this I'll happily update the website documentation.

Cheers

Daniel.
PS: also noticed git_folder in radicale/config.py ? Is this something in progress. I'm definitely interested in a git based storage and may implement this regardless.