### PR TITLE
Added HTTP-based authentication

### DIFF
--- a/config
+++ b/config
@@ -77,6 +77,13 @@ pam_group_membership =
 # Path to the Courier Authdaemon socket
 courier_socket =
 
+# HTTP authentication request URL endpoint
+auth_url =
+# POST param to use for username
+user_param = username
+# POST param to use for password
+password_param = password
+
 
 [rights]
 # Rights management method

--- a/radicale/auth/http.py
+++ b/radicale/auth/http.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2011 Corentin Le Bail
+# Copyright © 2011-2012 Guillaume Ayoub
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+HTTP authentication.
+
+Make a request to an authentication server with the username/password.
+Anything other than a 200/201 response is considered auth failure.
+
+"""
+
+import requests
+from .. import config, log
+
+AUTH_URL = config.get("auth", "auth_url")
+USER_PARAM = config.get("auth", "user_param")
+PASSWORD_PARAM = config.get("auth", "password_param")
+
+def is_authenticated(user, password):
+  payload = {USER_PARAM: user, PASSWORD_PARAM: password}
+  r = requests.post(AUTH_URL, data=payload)
+  return r.status_code in [200, 201]

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -51,6 +51,9 @@ INITIAL_CONFIG = {
         "stock": "utf-8"},
     "auth": {
         "type": "None",
+        "auth_url": "",
+        "user_param": "username",
+        "password_param": "password",
         "public_users": "public",
         "private_users": "private",
         "htpasswd_filename": "/etc/radicale/users",


### PR DESCRIPTION
The purpose of this is in order to tie CalDAV accounts to an external web
application. This application must provide a URL end point to which a POST
request can be made, with the username/password sent as the payload. A 200 or
201 response is considered successful authentication. Any other response is
a failure.
