### PR TITLE
Added -C command line flag for specifying configuration file location.

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -77,8 +77,16 @@ def run():
         "-D", "--debug", action="store_true",
         default=config.getboolean("logging", "debug"),
         help="print debug information")
-    options = parser.parse_args()[0]
+    parser.add_option(
+        "-C", "--config",default='',
+        help='use a specific configuration file')
 
+    options = parser.parse_args()[0]
+    
+    # Read in the configuration specified by the command line (if specified)
+    if options.config != '':
+        config.read(options.config)
+    
     # Update Radicale configuration according to options
     for option in parser.option_list:
         key = option.dest
@@ -86,7 +94,7 @@ def run():
             section = "logging" if key == "debug" else "server"
             value = getattr(options, key)
             config.set(section, key, str(value))
-
+    
     # Start logging
     log.start()
 


### PR DESCRIPTION
Many init scripts seem to prefer specifying a config file from the command line instead of an environment variable. I've added such a flag so that the config file location can be specified via such means.

Potential use cases include init scripts or situations in which multiple copies of Radicale must be run with separate configurations.
