### PR TITLE
IMAP SSL Improvement

### DIFF
--- a/config
+++ b/config
@@ -38,7 +38,7 @@ stock = utf-8
 
 [auth]
 # Authentication method
-# Value: None | htpasswd | LDAP | PAM | courier
+# Value: None | htpasswd | LDAP | IMAP | PAM | courier
 type = None
 
 # Usernames used for public collections, separated by a comma
@@ -51,6 +51,12 @@ htpasswd_filename = /etc/radicale/users
 # Htpasswd encryption method
 # Value: plain | sha1 | crypt
 htpasswd_encryption = crypt
+
+#IMAP Configuration
+imap_auth_host_name = localhost
+imap_auth_host_port = 143
+imap_auth_use_ssl = False
+
 
 # LDAP server URL, with protocol and port
 ldap_url = ldap://localhost:389/

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -57,6 +57,7 @@ INITIAL_CONFIG = {
         "htpasswd_encryption": "crypt",
         "imap_auth_host_name": "localhost",
         "imap_auth_host_port": "143",
+        "imap_auth_use_ssl": "False",
         "ldap_url": "ldap://localhost:389/",
         "ldap_base": "ou=users,dc=example,dc=com",
         "ldap_attribute": "uid",


### PR DESCRIPTION
Implementation of IMAP SSL Improvement, found in http://librelist.com/browser//radicale/2012/10/25/patch-imap-acl-ssl-improvement.

Without this, Radicale was not able to log in to my Dovecot IMAP Server, which is configured to accept only SSL logins.
