### PR TITLE
Typo: missing comma

### DIFF
--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -278,7 +278,7 @@ def _propfind_response(path, item, props, user):
             element.append(privilege)
         elif tag == _tag("D", "supported-report-set"):
             for report_name in (
-                    "principal-property-search", "sync-collection"
+                    "principal-property-search", "sync-collection",
                     "expand-property", "principal-search-property-set"):
                 supported = ET.Element(_tag("D", "supported-report"))
                 report_tag = ET.Element(_tag("D", "report"))


### PR DESCRIPTION
In PROPFIND answers sync-collection and expand-property are returned concatenated due to a missing comma.
