### PR TITLE
Fix logging config file setting

### DIFF
--- a/radicale/log.py
+++ b/radicale/log.py
@@ -36,18 +36,22 @@ LOGGER = logging.getLogger()
 
 def start():
     filename = os.path.expanduser(config.get("logging", "config"))
+    debug = config.getboolean("logging", "debug")
 
     """Start the logging according to the configuration."""
     if os.path.exists(filename):
         # Configuration taken from file
         logging.config.fileConfig(filename)
+        if debug:
+            LOGGER.setLevel(logging.DEBUG)
+            for handler in LOGGER.handlers:
+                handler.setLevel(logging.DEBUG)
     else:
         # Default configuration, standard output
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter("%(message)s"))
         LOGGER.addHandler(handler)
-
-    if config.getboolean("logging", "debug"):
-        LOGGER.setLevel(logging.DEBUG)
-        for handler in LOGGER.handlers:
-            handler.setLevel(logging.DEBUG)
+        if debug:
+            LOGGER.setLevel(logging.DEBUG)
+            LOGGER.debug("Logging configuration file '%s' not found, using stdout."
+                         % filename)


### PR DESCRIPTION
Setting a config file in the `[logging]` section didn't work.
The filename was read from the config object during load time of `radicale/log.py`.

This breaks when `-C` is used and the config object is updated after the `log` module import.

With my changes, the filename is now read from the config object in `log.start`.
