### PR TITLE
Fix __hash__ problem.

### DIFF
--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -110,9 +110,7 @@ class Item(object):
                 "\nEND:", "\nX-RADICALE-NAME:%s\nEND:" % self._name)
 
     def __hash__(self):
-        m = hashlib.md5()
-        m.update(self.text.encode('utf-8'))
-        return m.hexdigest()
+        return hash(self.text)
 
     def __eq__(self, item):
         return isinstance(item, Item) and self.text == item.text
@@ -124,7 +122,9 @@ class Item(object):
         Etag is mainly used to know if an item has changed.
 
         """
-        return '"%s"' % hash(self)
+        m = hashlib.md5()
+        m.update(self.text.encode('utf-8'))
+        return '"%s"' % m.hexdigest()
 
     @property
     def name(self):


### PR DESCRIPTION
`__hash__` must return an integer. The `hashlib` functions don't return anything that's simply converted to an integer, so I moved the MD5 hashing into the `etag` function and changed `__hash__` back to using the built-in `hash` function. I don't know if the difference between the hash and the ETag will be a problem. This is a quick fix for a serious problem that I caused.

I can't use Git on my test machine at the moment, so I had to copy the changes by hand into Github's editor. I made a mistake and I didn't test. I don't have access to my test machine right now, so I did this fix in Github's editor too. I triple-checked everything, but I can't test it right now.
