### PR TITLE
Fix wrong filename in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include COPYING NEWS.rst TODO.rst README.rst config logging radicale.py radicale.fcgi radicale.wsgi setup.sql
+include COPYING NEWS.rst TODO.rst README.rst config logging radicale.py radicale.fcgi radicale.wsgi schema.sql


### PR DESCRIPTION
-> no more warning when running `setup.py`
