### PR TITLE
Fix issues if authentication is done by web server

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -278,7 +278,11 @@ class Application(object):
             user, password = self.decode(base64.b64decode(
                 authorization.encode("ascii")), environ).split(":", 1)
         else:
-            user = password = None
+            password = None
+            try:
+                user = environ["REMOTE_USER"]
+            except KeyError:
+                user = None
 
         read_allowed_items, write_allowed_items = \
             self.collect_allowed_items(items, user)


### PR DESCRIPTION
This patch fixes `user` always being None if the authentication is
offloaded to the webserver, as it is suggested in the documentation.

For normal access, this is not a problem, but it becomes a problem if a
client wants to get the current-user-principal, for which the user name
is required.
