### PR TITLE
Fix syntax/logic problem when tag property doesn't exist yet

### DIFF
--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -35,7 +35,7 @@ from contextlib import contextmanager
 
 def rreplace(s, old, new, count = 1):
     """ Replace the rightmost count number of occurances of "old" in s with "new" """
-    li = s.rsplit(old, count(
+    li = s.rsplit(old, count)
     return new.join(li)
 
 def serialize(tag, headers=(), items=()):


### PR DESCRIPTION
Some simple bug fixing:

When the tag property doesn't exist yet in props, the tag variable isn't defined when the else statement is executed. also, if tag is successfully read, nothing is done with it.

I've cleaned the code up to the best of my understanding of what was intended.... However, I wonder if the "open" functionality should be moved to the filesystem backend... it doesn't seem to make sense here.
