### PR TITLE
Adding an hint for PAM authentification on Linux.

### DIFF
--- a/pages/user_documentation.rst
+++ b/pages/user_documentation.rst
@@ -827,6 +827,11 @@ The PAM authentication module relies on `the pam module
 <http://atlee.ca/software/pam/>`_, and thus only works with 2.x versions of
 Python.
 
+Bear in mind that on Linux systems, if you're authenticating against PAM
+files (i.e. ``/etc/shadow``), the user running Radicale must have the right
+permissions. For instance, you might want to add the ``radicale`` user
+to the ``shadow`` group.
+
 HTTP Authentication
 -------------------
 


### PR DESCRIPTION
As said, if PAM is configured to check against the system files, the user running Radicale must have the proper permissions.
