### PR TITLE
Fixing anonymous user being able to RW with any ACL setting.

### DIFF
--- a/radicale/rights/regex.py
+++ b/radicale/rights/regex.py
@@ -100,6 +100,17 @@ def authorized(user, collection, right):
     if collection_url in (".well-known/carddav", ".well-known/caldav"):
         return right == "r"
     rights_type = config.get("rights", "type").lower()
+
+    if user is None:
+        # This is an anonymous user
+        if rights_type != "none":
+            # Only the none ACL setting allows for anonymous read and write
+            log.LOGGER.debug(
+                "The current right management setting isn't 'none', "
+                "therefore anonymous users can't access collections."
+            )
+            return False
+
     return (
         rights_type == "none" or
         _read_from_sections(user or "", collection_url, right))


### PR DESCRIPTION
If we don't have this, the anonymous user will be checked in **_read_from_sections** against one of the following regex:

``` python
    "owner_write": "[r]\nuser:.*\ncollection:.*\npermission:r\n"
```

or:

``` python
    "owner_only": "[rw]\nuser:.*\ncollection:^%(login)s/.+$\npermission:rw",
```

via:

``` python
    user_match = re.match(re_user, user)
```

Now since an anonymous user means:
- **user == None** in **authorized(user,collection, right)**, 
- and **user == ""** in **_read_from_sections(user,collection, permission)**,

**re.match(".*", "")** will always return **True**, giving at least the read permission for anonymous users.

Here we bypass the **_read_from_sections** process, as it was intented by:

``` python
  return (
      rights_type == "none" or
  ...
```

If **rights_type** is not **'none'**, then there is no reason for us to check permissions for an unauthenticated user.

/!\ Warning /!: this may break current working configuration, since during my tests I could see that my calendar client (Kmail) first tries to anonymously fetch the collections, and will only provide authentication if it gets bumped. So as of now, users with insufficient permissions or wrong passwords are able to fetch collections, but if you apply this fix, users with insufficient permissions or wrong passwords will result in being unable to fetch the collections (which should be the correct behavior).
