### PR TITLE
Adding a new "authenticated" ACL type.

### DIFF
--- a/config
+++ b/config
@@ -104,7 +104,7 @@ committer = Radicale <radicale@example.com>
 
 [rights]
 # Rights backend
-# Value: None | owner_only | owner_write | from_file | custom
+# Value: None | authenticated | owner_only | owner_write | from_file | custom
 type = None
 
 # Custom rights handler

--- a/radicale/rights/regex.py
+++ b/radicale/rights/regex.py
@@ -52,9 +52,11 @@ except ImportError:
 
 
 DEFINED_RIGHTS = {
+    "authenticated": "[rw]\nuser:.*\ncollection:.*\npermission:rw",
     "owner_write": "[r]\nuser:.*\ncollection:.*\npermission:r\n"
                    "[w]\nuser:.*\ncollection:^%(login)s/.+$\npermission:w",
-    "owner_only": "[rw]\nuser:.*\ncollection:^%(login)s/.+$\npermission:rw"}
+    "owner_only": "[rw]\nuser:.*\ncollection:^%(login)s/.+$\npermission:rw",
+}
 
 
 def _read_from_sections(user, collection, permission):


### PR DESCRIPTION
When set, all authenticated users will have rw permissions on all
collections, but no anonymous user will be able to read or write any
collection.
