### PR TITLE
Allow tilde expansion for htpasswd file

### DIFF
--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -29,11 +29,12 @@ supported, but md5 is not (see ``htpasswd`` man page to understand why).
 
 import base64
 import hashlib
+import os
 
 from .. import config
 
 
-FILENAME = config.get("auth", "htpasswd_filename")
+FILENAME = os.path.expanduser(config.get("auth", "htpasswd_filename"))
 ENCRYPTION = config.get("auth", "htpasswd_encryption")
 
 


### PR DESCRIPTION
Call os.path.expanduser on the location given by the config parameter.
This will allow to use settings like
  htpasswd_filename = ~/.config/radicale/users
