### PR TITLE
Return "401 unauthorized" on unauthorized DELETE requests (fixes #125)

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -340,7 +340,7 @@ class Application(object):
                user):
         """Manage DELETE request."""
         if not len(write_collections):
-            return client.PRECONDITION_FAILED, {}, None
+            return return NOT_ALLOWED
 
         collection = write_collections[0]
 


### PR DESCRIPTION
This commit fixes issue #125 (return "401 unauthorized" instead of "412 Precondition Failed" on unauthorized DELETE requests). This gives clients the chance to (re)send credentials and actually succeed in deleting entries if they were not authenticated before.
