### PR TITLE
django integration

### DIFF
--- a/radicale/admin.py
+++ b/radicale/admin.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Okami <okami@fuzetsu.info>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Django admin web interface.
+"""
+
+from django import forms
+from django.contrib import admin
+from django.db import models
+
+from .models import DBCollection, DBItem, DBHeader, DBLine, DBProperty
+
+
+class TextInputAdmin(object):
+    formfield_overrides = {
+        models.TextField: {'widget': forms.TextInput},
+    }
+
+
+class DBHeaderInline(TextInputAdmin, admin.TabularInline):
+    extra = 0
+    model = DBHeader
+
+
+class DBPropertyInline(TextInputAdmin, admin.TabularInline):
+    extra = 0
+    model = DBProperty
+
+
+class DBCollectionAdmin(TextInputAdmin, admin.ModelAdmin):
+    inlines = DBHeaderInline, DBPropertyInline
+    list_display = 'path', 'parent'
+    list_filter = 'parent',
+    search_fields = 'path',
+    fields = 'path', 'parent'
+
+
+class DBLineInline(TextInputAdmin, admin.TabularInline):
+    extra = 0
+    model = DBLine
+
+
+class DBItemAdmin(TextInputAdmin, admin.ModelAdmin):
+    inlines = DBLineInline,
+    list_display = 'name', 'tag'
+    list_filter = 'tag', 'collection'
+    search_fields = 'name', 'tag'
+    fields = 'name', 'tag', 'collection'
+
+
+admin.site.register(DBCollection, DBCollectionAdmin)
+admin.site.register(DBItem, DBItemAdmin)

--- a/radicale/auth/django.py
+++ b/radicale/auth/django.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2008 Nicolas Kandel
+# Copyright © 2008 Pascal Halter
+# Copyright © 2008-2013 Guillaume Ayoub
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Django authentication.
+"""
+
+from django.contrib.auth import authenticate
+
+
+def is_authenticated(user, password):
+    user = authenticate(username=user, password=password)
+    if user is not None:
+        if user.is_active:
+            return True
+    return False

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -4,6 +4,7 @@
 # Copyright © 2008-2013 Guillaume Ayoub
 # Copyright © 2008 Nicolas Kandel
 # Copyright © 2008 Pascal Halter
+# Copyright © 2014 Okami <okami@fuzetsu.info>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,10 +99,16 @@ for section, values in INITIAL_CONFIG.items():
     for key, value in values.items():
         _CONFIG_PARSER.set(section, key, value)
 
-_CONFIG_PARSER.read("/etc/radicale/config")
-_CONFIG_PARSER.read(os.path.expanduser("~/.config/radicale/config"))
-if "RADICALE_CONFIG" in os.environ:
-    _CONFIG_PARSER.read(os.environ["RADICALE_CONFIG"])
+try:
+    from django.conf import settings
+    for section, values in settings.RADICALE_CONFIG.items():
+        for key, value in values.items():
+            _CONFIG_PARSER.set(section, key, value)
+except:
+    _CONFIG_PARSER.read("/etc/radicale/config")
+    _CONFIG_PARSER.read(os.path.expanduser("~/.config/radicale/config"))
+    if "RADICALE_CONFIG" in os.environ:
+        _CONFIG_PARSER.read(os.environ["RADICALE_CONFIG"])
 
 # Wrap config module into ConfigParser instance
 sys.modules[__name__] = _CONFIG_PARSER

--- a/radicale/log.py
+++ b/radicale/log.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Radicale Server - Calendar Server
 # Copyright © 2011-2013 Guillaume Ayoub
+# Copyright © 2014 Okami <okami@fuzetsu.info>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,7 +33,7 @@ import logging.config
 from . import config
 
 
-LOGGER = logging.getLogger()
+LOGGER = logging.getLogger('radicale')
 
 
 def start():

--- a/radicale/models.py
+++ b/radicale/models.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Okami <okami@fuzetsu.info>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Django models. Used in django storage backend.
+"""
+
+from django.db import models
+
+
+class DBCollection(models.Model):
+    """Table of collections."""
+
+    path = models.TextField('Path', primary_key=True)
+    parent = models.ForeignKey(
+        'DBCollection', verbose_name='Parent Collection',
+        related_name='children', blank=True, null=True)
+
+    def __str__(self):
+        return self.path
+
+    def __unicode__(self):
+        return self.path
+
+    class Meta(object):
+        db_table = 'radicale_collection'
+        verbose_name = 'Collection'
+        verbose_name_plural = 'Collections'
+
+
+class DBItem(models.Model):
+    """Table of collection's items."""
+
+    name = models.TextField('Name', primary_key=True)
+    tag = models.TextField('Tag')
+    collection = models.ForeignKey(
+        'DBCollection', verbose_name='Collection', related_name='items')
+
+    def __str__(self):
+        return self.name
+
+    def __unicode__(self):
+        return self.name
+
+    class Meta(object):
+        db_table = 'radicale_item'
+        verbose_name = 'Item'
+        verbose_name_plural = 'Items'
+
+
+class DBHeader(models.Model):
+    """Table of item's headers."""
+
+    name = models.TextField('Name', primary_key=True)
+    value = models.TextField('Value')
+    collection = models.ForeignKey(
+        'DBCollection', verbose_name='Collection', related_name='headers')
+
+    def __str__(self):
+        return '%s=%s' % (self.name, self.value)
+
+    def __unicode__(self):
+        return u'%s=%s' % (self.name, self.value)
+
+    class Meta(object):
+        db_table = 'radicale_header'
+        verbose_name = 'Header'
+        verbose_name_plural = 'Headers'
+
+
+class DBLine(models.Model):
+    """Table of item's lines."""
+
+    name = models.TextField('Name')
+    value = models.TextField('Value')
+    timestamp = models.DateTimeField(
+        'Timestamp', auto_now_add=True, primary_key=True)
+    item = models.ForeignKey(
+        'DBItem', verbose_name='Item', related_name='lines')
+
+    def __str__(self):
+        return '%s=%s' % (self.name, self.value)
+
+    def __unicode__(self):
+        return u'%s=%s' % (self.name, self.value)
+
+    class Meta(object):
+        db_table = 'radicale_line'
+        ordering = 'timestamp',
+        verbose_name = 'Line'
+        verbose_name_plural = 'Lines'
+
+
+class DBProperty(models.Model):
+    """Table of collection's properties."""
+
+    name = models.TextField('Name', primary_key=True)
+    value = models.TextField('Value')
+    collection = models.ForeignKey(
+        'DBCollection', verbose_name='Collection', related_name='properties')
+
+    def __str__(self):
+        return '%s=%s' % (self.name, self.value)
+
+    def __unicode__(self):
+        return u'%s=%s' % (self.name, self.value)
+
+    class Meta(object):
+        db_table = 'radicale_property'
+        verbose_name = 'Property'
+        verbose_name_plural = 'Properties'

--- a/radicale/rights/django.py
+++ b/radicale/rights/django.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Okami <okami@fuzetsu.info>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Django settings-based rights management.
+"""
+
+import re
+
+# Manage Python2/3 different modules
+# pylint: disable=F0401
+try:
+    from configparser import RawConfigParser as ConfigParser
+except ImportError:
+    from ConfigParser import RawConfigParser as ConfigParser
+# pylint: enable=F0401
+
+from django.conf import settings
+
+from .. import log
+
+
+# Default configuration
+INITIAL_RIGHTS = {
+    "rw": {
+        "user": ".+",
+        "collection": ".*",
+        "permission": "rw"}}
+
+
+def _read_from_sections(user, collection_url, permission):
+    """Get regex sections."""
+    regex = ConfigParser({"login": user, "path": collection_url})
+    for rights in (INITIAL_RIGHTS, settings.RADICALE_RIGHTS):
+        for section, values in rights.items():
+            if not regex.has_section(section):
+                regex.add_section(section)
+            for key, value in values.items():
+                regex.set(
+                    section, key,
+                    value % {"login": user, "path": collection_url})
+    log.LOGGER.debug("Rights type '%s'" % __name__)
+
+    for section in regex.sections():
+        re_user = regex.get(section, "user")
+        re_collection = regex.get(section, "collection")
+        log.LOGGER.debug(
+            "Test if '%s:%s' matches against '%s:%s' from section '%s'" % (
+                user, collection_url, re_user, re_collection, section))
+        user_match = re.match(re_user, user)
+        if user_match:
+            re_collection = re_collection.format(*user_match.groups())
+            if re.match(re_collection, collection_url):
+                log.LOGGER.debug("Section '%s' matches" % section)
+                if permission in regex.get(section, "permission"):
+                    return True
+            else:
+                log.LOGGER.debug("Section '%s' does not match" % section)
+    return False
+
+
+def authorized(user, collection, permission):
+    """Check if the user is allowed to read or write the collection.
+
+       If the user is empty it checks for anonymous rights
+    """
+    collection_url = collection.url.rstrip("/") or "/"
+    if collection_url in (".well-known/carddav", ".well-known/caldav"):
+        return permission == "r"
+    return _read_from_sections(user or "", collection_url, permission)

--- a/radicale/storage/django.py
+++ b/radicale/storage/django.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Okami <okami@fuzetsu.info>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Django storage backend.
+
+"""
+
+import time
+from datetime import datetime
+from contextlib import contextmanager
+
+from django.db.models import Q
+
+from .. import ical
+from ..models import DBCollection, DBItem, DBHeader, DBLine, DBProperty
+
+
+class Collection(ical.Collection):
+    """Collection stored in a django database."""
+
+    def _query(self, item_types):
+        """Get collection's items matching ``item_types``."""
+        item_objects = []
+        for item_type in item_types:
+            items = (
+                DBItem.objects
+                .filter(collection__path=self.path, tag=item_type.tag)
+                .order_by('name'))
+            for item in items:
+                text = '\n'.join(map(
+                    lambda x: '%s:%s' % x,
+                    item.lines.values_list('name', 'value')))
+                item_objects.append(item_type(text, item.name))
+        return item_objects
+
+    @property
+    def _modification_time(self):
+        """Collection's last modification time."""
+        lines = DBLine.objects.filter(item__collection__path=self.path)
+        if lines.exists():
+            return lines.latest('timestamp').timestamp
+        else:
+            return datetime.now()
+
+    @property
+    def _db_collection(self):
+        """Collection's object mapped to the table line."""
+        db_collection = DBCollection.objects.filter(path=self.path)
+        if db_collection.exists():
+            return db_collection.get()
+
+    def write(self, headers=None, items=None):
+        headers = headers or self.headers or (
+            ical.Header("PRODID:-//Radicale//NONSGML Radicale Server//EN"),
+            ical.Header("VERSION:%s" % self.version))
+        items = items if items is not None else self.items
+
+        if self._db_collection:
+            for item in self._db_collection.items.all():
+                item.lines.all().delete()
+                item.delete()
+            self._db_collection.headers.all().delete()
+        else:
+            db_collection = DBCollection()
+            db_collection.path = self.path
+            parent, created = DBCollection.objects.get_or_create(
+                path='/'.join(self.path.split('/')[:-1]))
+            db_collection.parent = parent
+            db_collection.save()
+
+        for header in headers:
+            db_header = DBHeader()
+            db_header.name, db_header.value = header.text.split(":", 1)
+            db_header.collection = self._db_collection
+            db_header.save()
+
+        for item in items:
+            db_item = DBItem()
+            db_item.name = item.name
+            db_item.tag = item.tag
+            db_item.collection = self._db_collection
+            db_item.save()
+
+            for line in ical.unfold(item.text):
+                db_line = DBLine()
+                db_line.name, db_line.value = line.split(":", 1)
+                db_line.item = db_item
+                db_line.save()
+
+    def delete(self):
+        self._db_collection.delete()
+
+    @property
+    def text(self):
+        return ical.serialize(self.tag, self.headers, self.items)
+
+    @property
+    def etag(self):
+        return '"%s"' % hash(self._modification_time)
+
+    @property
+    def headers(self):
+        headers = (
+            DBHeader.objects
+            .filter(collection__path=self.path)
+            .order_by('name'))
+        return [
+            ical.Header("%s:%s" % x)
+            for x in headers.values_list('name', 'value')]
+
+    @classmethod
+    def children(cls, path):
+        children = (
+            DBCollection.objects
+            .filter(Q(parent__path=path or '')))
+        collections = [cls(child.path) for child in children]
+        return collections
+
+    @classmethod
+    def is_node(cls, path):
+        if not path:
+            return True
+        result = (
+            DBCollection.objects
+            .filter(Q(parent__path=path or ''))
+            .count() > 0)
+        return result
+
+    @classmethod
+    def is_leaf(cls, path):
+        if not path:
+            return False
+        result = (
+            DBItem.objects
+            .filter(
+                Q(collection__path=path or ''))
+            .count() > 0)
+        return result
+
+    @property
+    def last_modified(self):
+        return time.strftime(
+            "%a, %d %b %Y %H:%M:%S +0000", self._modification_time.timetuple())
+
+    @property
+    @contextmanager
+    def props(self):
+        # On enter
+        db_properties = (
+            DBProperty.objects
+            .filter(collection__path=self.path))
+        properties = dict(db_properties.values_list('name', 'value'))
+        old_properties = properties.copy()
+        yield properties
+        # On exit
+        if self._db_collection and old_properties != properties:
+            db_properties.all().delete()
+            for name, value in properties.items():
+                prop = DBProperty()
+                prop.name = name
+                prop.value = value
+                prop.collection = self._db_collection
+                prop.save()
+
+    @property
+    def items(self):
+        return self._query(
+            (ical.Event, ical.Todo, ical.Journal, ical.Card, ical.Timezone))
+
+    @property
+    def components(self):
+        return self._query((ical.Event, ical.Todo, ical.Journal, ical.Card))
+
+    @property
+    def events(self):
+        return self._query((ical.Event,))
+
+    @property
+    def todos(self):
+        return self._query((ical.Todo,))
+
+    @property
+    def journals(self):
+        return self._query((ical.Journal,))
+
+    @property
+    def timezones(self):
+        return self._query((ical.Timezone,))
+
+    @property
+    def cards(self):
+        return self._query((ical.Card,))
+
+    def save(self):
+        """Save the text into the collection.
+
+        This method is not used for databases.
+
+        """

--- a/radicale/urls.py
+++ b/radicale/urls.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Okami <okami@fuzetsu.info>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Django URLs.
+"""
+
+from django.conf.urls import patterns, url
+
+urlpatterns = patterns(
+    'radicale.views',
+    url(r'^(?P<url>.*)$', 'application', name='application'),
+)

--- a/radicale/views.py
+++ b/radicale/views.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Okami <okami@fuzetsu.info>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Django CBV.
+"""
+
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import View
+from django.utils.decorators import method_decorator
+from . import Application
+
+
+class ApplicationResponse(HttpResponse):
+    def start_response(self, status, headers):
+        self.status_code = int(status.split(' ')[0])
+        for k, v in dict(headers).items():
+            self[k] = v
+
+
+class ApplicationView(Application, View):
+    http_method_names = [
+        'delete',
+        'get',
+        'head',
+        'mkcalendar',
+        'mkcol',
+        'move',
+        'options',
+        'propfind',
+        'proppatch',
+        'put',
+        'report',
+    ]
+
+    def __init__(self, **kwargs):
+        """Initialize application."""
+        super(ApplicationView, self).__init__()
+        super(View, self).__init__(**kwargs)
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request, *args, **kwargs):
+        if not request.method.lower() in self.http_method_names:
+            return self.http_method_not_allowed(request, *args, **kwargs)
+        response = ApplicationResponse()
+        answer = self(request.META, response.start_response)
+        if answer:
+            response.write(answer[0])
+        return response
+
+
+application = ApplicationView.as_view()


### PR DESCRIPTION
It's possible to use radicale as a regular django application in any django project.

Difference in configuration:
1. All settings should be put in RADICALE_CONFIG dictionary inside django project setting.py instead of a config file.
2. "server" section is ignored (not sure about "base_prefix" and "realm" atm).
3. "auth" section has new option for "type" - "django", for authenticating using regular django users.
4. "storage" section has new option for "type" - "django", for using django models as a storage. It's possible to edit/view them using django admin web interface.
5. "rights" section has new rights handler "radicale.rights.django", for using rights configuration from RADICALE_RIGHTS inside django project setting.py.
6. "log" section is ignored, regular django LOGGING settings should be used instead.

Installation:
Put this in your project's settings.py:

```
RADICALE_CONFIG = {
    "server": {
        "base_prefix": "/",
        "realm": "Radicale - Password Required",
    },
    "encoding": {
        "request": "utf-8",
        "stock": "utf-8",
    },
    "auth": {
        "type": "django",
        "custom_handler": "",
        "htpasswd_filename": "/etc/radicale/users",
        "htpasswd_encryption": "crypt",
        "imap_hostname": "localhost",
        "imap_port": "143",
        "imap_ssl": "False",
        "ldap_url": "ldap://localhost:389/",
        "ldap_base": "ou=users,dc=example,dc=com",
        "ldap_attribute": "uid",
        "ldap_filter": "",
        "ldap_binddn": "",
        "ldap_password": "",
        "ldap_scope": "OneLevel",
        "pam_group_membership": "",
        "courier_socket": "",
        "http_url": "",
        "http_user_parameter": "",
        "http_password_parameter": "",
    },
    "git": {
        "committer": "Radicale <radicale@example.com>",
    },
    "rights": {
        "type": "custom",
        "custom_handler": "radicale.rights.django",
        "file": "~/.config/radicale/rights",
    },
    "storage": {
        "type": "django",
        "custom_handler": "",
        "filesystem_folder": os.path.expanduser(
            "~/.config/radicale/collections"),
        "database_url": "",
    },
}
```

This is basic recommended settings with a maximum of the options available. You don't need all of them, because some of the options is depended on each other. You can modify them as you want. You can use any available auth, storage, rights backends, not only the "django" ones.

Configuration for the "radicale.rights.django" handler can be changed by setting RADICALE_RIGHTS in your project's settings.py.
For example:

```
RADICALE_RIGHTS = {
    "rw": {
        "user": ".+",
        "collection": "^pim/%(login)s\.vcf$",
        "permission": "rw",
    },
}
```

Put this line inside your urlpatterns in your project's urls.py:

```
    url(r'^addressbook/', include('radicale.urls')),
```

You can replace "addressbook" with anything you want.
