### PR TITLE
Improve Git commit behavior on replace()

### DIFF
--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -31,6 +31,7 @@ import hashlib
 from uuid import uuid4
 from random import randint
 from contextlib import contextmanager
+import log
 
 
 def serialize(tag, headers=(), items=()):
@@ -251,7 +252,7 @@ class Collection(object):
                 result.extend(collection.components)
         return result
 
-    def save(self, text):
+    def save(self, text, message=None):
         """Save the text into the collection."""
         raise NotImplementedError
 
@@ -367,7 +368,7 @@ class Collection(object):
             if new_item.name not in (item.name for item in items):
                 items.append(new_item)
 
-        self.write(items=items)
+        self.write(items=items, message="Add %s" % name)
 
     def remove(self, name):
         """Remove object named ``name`` from collection."""
@@ -376,14 +377,22 @@ class Collection(object):
             if component.name != name]
 
         items = self.timezones + components
-        self.write(items=items)
+        self.write(items=items, message="Remove %s" % name)
 
     def replace(self, name, text):
-        """Replace content by ``text`` in collection objet called ``name``."""
-        self.remove(name)
-        self.append(name, text)
+        """Replace content by ``text`` in collection object called ``name``."""
+        components = [
+            component for component in self.components
+            if component.name != name]
 
-    def write(self, headers=None, items=None):
+        new_item = self._parse(
+                text, (Timezone, Event, Todo, Journal, Card), name)[0]
+        components.append(new_item)
+
+        items = self.timezones + components
+        self.write(items=items, message="Modify %s" % name)
+
+    def write(self, headers=None, items=None, message=None):
         """Write collection with given parameters."""
         headers = headers or self.headers or (
             Header("PRODID:-//Radicale//NONSGML Radicale Server//EN"),
@@ -391,7 +400,8 @@ class Collection(object):
         items = items if items is not None else self.items
 
         text = serialize(self.tag, headers, items)
-        self.save(text)
+        log.LOGGER.info(message)
+        self.save(text, message=message)
 
     def set_mimetype(self, mimetype):
         """Set the mimetype of the collection."""

--- a/radicale/storage/filesystem.py
+++ b/radicale/storage/filesystem.py
@@ -44,7 +44,7 @@ except:
 # This function overrides the builtin ``open`` function for this module
 # pylint: disable=W0622
 @contextmanager
-def open(path, mode="r"):
+def open(path, mode="r", commitmessage=None):
     """Open a file at ``path`` with encoding set in the configuration."""
     # On enter
     abs_path = os.path.join(FOLDER, path.replace("/", os.sep))
@@ -55,7 +55,8 @@ def open(path, mode="r"):
         path = os.path.relpath(abs_path, FOLDER)
         GIT_REPOSITORY.stage([path])
         committer = config.get("git", "committer")
-        GIT_REPOSITORY.do_commit("Commit by Radicale", committer=committer)
+        commitmessage = commitmessage or "Commit by Radicale"
+        GIT_REPOSITORY.do_commit(commitmessage, committer=committer)
 # pylint: enable=W0622
 
 
@@ -76,9 +77,9 @@ class Collection(ical.Collection):
         if not os.path.exists(os.path.dirname(self._path)):
             os.makedirs(os.path.dirname(self._path))
 
-    def save(self, text):
+    def save(self, text, message=None):
         self._create_dirs()
-        with open(self._path, "w") as fd:
+        with open(self._path, "w", commitmessage = message) as fd:
             fd.write(text)
 
     def delete(self):


### PR DESCRIPTION
Implement replace() instead of composing remove() and append(), so that
it performs not two independent but a single, concise transaction on the
storage backend. This is generally more efficient and especially
desirable when Git support is enabled.

This change also adds slightly more informative commit messages.