### PR TITLE
deplace pid file creation in child process

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -103,11 +103,10 @@ def run():
             raise OSError("PID file exists: %s" % config.get("server", "pid"))
         pid = os.fork()
         if pid:
-            try:
-                if config.get("server", "pid"):
-                    open(config.get("server", "pid"), "w").write(str(pid))
-            finally:
-                sys.exit()
+            sys.exit()
+        else:
+            if config.get("server", "pid"):
+                open(config.get("server", "pid"), "w").write(str(pid))
         sys.stdout = sys.stderr = open(os.devnull, "w")
 
     # Register exit function


### PR DESCRIPTION
Currently, the pid file is created by the parent. If the file can't be created (which might happens for several reason), parent fails and exit silently whereas child keep running. At exit, it tries to delete its pid file, which does not exists and crash.
With that patch, child exits whenever pid file can't be created, as does nginx and mysql, for example.

It's mostly important for behaving correctly when running under sub-privileged user, like a lot of linux distribution does. It's currently somewhat a bug on red Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1122049
