### PR TITLE
Return user basepath for current-user-principal

### DIFF
--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -297,10 +297,7 @@ def _propfind_response(path, item, props, user):
             # pylint: enable=W0511
         elif tag == _tag("D", "current-user-principal") and user:
             tag = ET.Element(_tag("D", "href"))
-            if item.resource_type == "addressbook":
-                tag.text = _href("/%s/addressbook.vcf/" % user)
-            else:
-                tag.text = _href("/%s/calendar.ics/" % user)
+            tag.text = _href("/%s/" % user)
             element.append(tag)
         elif tag == _tag("D", "current-user-privilege-set"):
             privilege = ET.Element(_tag("D", "privilege"))


### PR DESCRIPTION
Fix #196

The way to do collection discovery described in 
http://stackoverflow.com/a/11673483 doesn't work well with Radicale:
1. current-user-principal returns /user/calendar.ics/
2. PROPFINDs asking
   for calendar-home-set will return the URL that was
   used in the request, which is still /user/calendar.ics/
3. The final PROPFIND with Depth: 1 is supposed to list all
   collections, but because the request is done with a collection URL,
   Radicale returns the items for the "calendar.ics" collection which
   might or might not exist.
