### PR TITLE
Add Dovecot auth

### DIFF
--- a/config
+++ b/config
@@ -73,7 +73,7 @@
 [auth]
 
 # Authentication method
-# Value: None | htpasswd | IMAP | LDAP | PAM | courier | http | remote_user | custom
+# Value: None | htpasswd | IMAP | LDAP | PAM | courier | dovecot | http | remote_user | custom
 #type = None
 
 # Custom authentication handler
@@ -121,6 +121,9 @@
 
 # Path to the Courier Authdaemon socket
 #courier_socket =
+
+# Path to the Dovecot Auth socket
+dovecot_socket =
 
 # HTTP authentication request URL endpoint
 #http_url =

--- a/radicale/auth/dovecot.py
+++ b/radicale/auth/dovecot.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Giel van Schijndel
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Dovecot Authentication Protocol v1.1
+
+"""
+
+import base64
+import itertools
+import os
+import sys
+import socket
+
+from contextlib import closing
+from .. import config, log
+
+DOVECOT_SOCKET = config.get("auth", "dovecot_socket")
+
+request_id_gen = itertools.count(1)
+
+def is_authenticated(user, password):
+    """Check if ``user``/``password`` couple is valid according to Dovecot.
+
+    This implementation communicates with a Dovecot server through the
+    Dovecot Authentication Protocol v1.1.
+
+    http://wiki2.dovecot.org/Design/AuthProtocol
+    """
+
+    if not user or not password:
+        return False
+
+    with closing(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)) as sock:
+        try:
+            sock.settimeout(5)
+
+            sock.connect(DOVECOT_SOCKET)
+
+            # Handshake
+            sock.send("VERSION\t1\t1\n")
+            sock.send("CPID\t{pid}\n".format(pid=os.getpid()))
+
+            buf = bytes()
+            supported_mechs = []
+            done = False
+            while not done:
+                buf += sock.recv(8192)
+                while bytes('\n') in buf and not done:
+                    line, buf = buf.split('\n', 1)
+                    parts = line.split('\t')
+                    first, parts = parts[0], parts[1:]
+
+                    if first == 'VERSION':
+                        version = parts
+                        if int(version[0]) != 1:
+                            log.LOGGER.error("Dovecot server version is not 1.x. it is %s", '.'.join(version))
+                            return False
+                    elif first == "MECH":
+                        supported_mechs.append(parts[0])
+                    elif first == "DONE":
+                        done = True
+
+            if "PLAIN" not in supported_mechs:
+                log.LOGGER.error("Dovecot doesn't appear to support PLAIN authentication, we need it. Only %s are supported", ', '.join(supported_mechs))
+                return False
+
+            request_id = next(request_id_gen)
+            sock.send("AUTH\t{request_id}\tPLAIN\tservice={arg0}\t{params}\n".format(
+                        request_id=request_id,
+                        arg0=sys.argv[0],
+                        params='resp={}'.format(base64.b64encode("\0{}\0{}".format(user, password))),
+                    ))
+
+            buf = sock.recv(8192)
+            line = buf.split('\n', 1)[0]
+            parts = line.split('\t')[:2]
+            resp, reply_id, params = parts[0], int(parts[1]), dict(part.split('=', 1) for part in parts[2:])
+
+            if request_id != reply_id:
+                log.LOGGER.error("Unexpected reply ID %d (request was %d)", reply_id, request_id)
+                return False
+
+            return resp == 'OK'
+        except socket.error as e:
+            log.LOGGER.exception("Unable to communicate with Dovecot auth socket: %s", e)
+            return False

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -76,7 +76,8 @@ INITIAL_CONFIG = {
         "courier_socket": "",
         "http_url": "",
         "http_user_parameter": "",
-        "http_password_parameter": ""},
+        "http_password_parameter": "",
+        "dovecot_socket": ""},
     "git": {
         "committer": "Radicale <radicale@example.com>"},
     "rights": {


### PR DESCRIPTION
This adds code to authenticate against a Dovecot server *without* resorting to IMAP. It uses [Dovecot's Authentication Protocol][1] to communicate directly with Dovecot through a local/unix socket. This is functionally similar to the Courier auth module.

The primary advantage of using this instead of the IMAP module is that a CalDAV sync doesn't cause syslog to be spammed with lots of login/logout events in a short amount of time (I've seen bursts of 10/sec sustained for about a minute during initial download of a calendar).

[1]: http://wiki2.dovecot.org/Design/AuthProtocol