### PR TITLE
MKCOL: don't crash when trying to create a "regular" collection

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -481,6 +481,9 @@ class Application(object):
 
         collection = write_collections[0]
 
+        if content is None:
+            return client.PRECONDITION_FAILED, {}, None
+
         props = xmlutils.props_from_request(content)
         with collection.props as collection_props:
             for key, value in props.items():


### PR DESCRIPTION
Currently when trying MKCOL through a regular WebDAV client such as cadaver I get an exception and a traceback instead of a decent client error (4xx). This fixes that by considering a missing request-body for MKCOL to be HTTP/WebDAV precondition failure and reports it to the client as such.