### PR TITLE
IMAP: don't spam the logs about non-SSL connections to localhost

### DIFF
--- a/radicale/auth/IMAP.py
+++ b/radicale/auth/IMAP.py
@@ -40,9 +40,12 @@ IMAP_SERVER = config.get("auth", "imap_hostname")
 IMAP_SERVER_PORT = config.getint("auth", "imap_port")
 IMAP_USE_SSL = config.getboolean("auth", "imap_ssl")
 
+IMAP_WARNED_UNENCRYPTED = False
 
 def is_authenticated(user, password):
     """Check if ``user``/``password`` couple is valid."""
+    global IMAP_WARNED_UNENCRYPTED
+
     if not user or not password:
         return False
 
@@ -72,7 +75,8 @@ def is_authenticated(user, password):
                 "IMAP server at %s failed to accept TLS connection "
                 "because of: %s" % (IMAP_SERVER, exception))
 
-    if server_is_local and not connection_is_secure:
+    if server_is_local and not connection_is_secure and not IMAP_WARNED_UNENCRYPTED:
+        IMAP_WARNED_UNENCRYPTED = True
         log.LOGGER.warning(
             "IMAP server is local. "
             "Will allow transmitting unencrypted credentials.")


### PR DESCRIPTION
When using IMAP auth with localhost as an IMAP server it is *not* unreasonable *not* to use SSL. (i.e. it is reasonable not to use SSL/encryption). Unfortunately the current logging strategy doesn't reflect that because on average 50% of the log messages coming from Radicale (with level=INFO set in log config) are about "transmitting unencrypted credentials".

This change reduces the spaminess of that. Although I personally don't think it would be a bad idea to remove the message altogether in case of localhost, there might be some servers configured with 'localhost' referring an external host where this message might be relevant. Thus my reason for leaving the message in while only reducing its frequency.