### PR TITLE
Do not autocreate .props files for multifilesystem backend

### DIFF
--- a/radicale/storage/multifilesystem.py
+++ b/radicale/storage/multifilesystem.py
@@ -23,10 +23,12 @@ Multi files per calendar filesystem storage backend.
 """
 
 import os
+import json
 import shutil
 import time
 import sys
 
+from contextlib import contextmanager
 from . import filesystem
 from .. import ical
 
@@ -96,3 +98,20 @@ class Collection(filesystem.Collection):
             os.path.getmtime(os.path.join(self._path, filename))
             for filename in os.listdir(self._path)] or [0])
         return time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime(last))
+
+    @property
+    @contextmanager
+    def props(self):
+        # On enter
+        properties = {}
+        if os.path.exists(self._props_path):
+            with open(self._props_path) as prop_file:
+                properties.update(json.load(prop_file))
+        old_properties = properties.copy()
+        yield properties
+        # On exit
+        if os.path.exists(self._props_path):
+          self._create_dirs()
+          if old_properties != properties:
+              with open(self._props_path, "w") as prop_file:
+                  json.dump(properties, prop_file)


### PR DESCRIPTION
This is required as we do not want .props files to be created for nodes,
otherwise they'll stop being considered as nodes, which will break
discovery of calendars.

This fixes https://github.com/Kozea/Radicale/issues/208