### PR TITLE
only iterate props in REPORT request if they are there

### DIFF
--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -464,7 +464,7 @@ def report(path, xml_request, collection):
     root = ET.fromstring(xml_request.encode("utf8"))
 
     prop_element = root.find(_tag("D", "prop"))
-    props = [prop.tag for prop in prop_element]
+    props = [prop.tag for prop in prop_element] if prop_element else []
 
     if collection:
         if root.tag in (_tag("C", "calendar-multiget"),


### PR DESCRIPTION
This error can be caused by a request with the following content (as done for example by caldavzap):

```
<?xml version="1.0" encoding="utf-8"?>
<A:expand-property xmlns:A="DAV:">
<A:property name="calendar-proxy-read-for" namespace="http://calendarserver.org/ns/">
<A:property name="email-address-set" namespace="http://calendarserver.org/ns/"/>
<A:property name="displayname" namespace="DAV:"/>
<A:property name="calendar-user-address-set" namespace="urn:ietf:params:xml:ns:caldav"/>
</A:property><A:property name="calendar-proxy-write-for" namespace="http://calendarserver.org/ns/"><A:property name="email-address-set" namespace="http://calendarserver.org/ns/"/>
<A:property name="displayname" namespace="DAV:"/>
<A:property name="calendar-user-address-set" namespace="urn:ietf:params:xml:ns:caldav"/>
</A:property>
</A:expand-property>
```
