### PR TITLE
Fix color support / duplicate namespace

### DIFF
--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -455,9 +455,9 @@ class Collection(object):
     def color(self):
         """Collection color."""
         with self.props as props:
-            if "A:calendar-color" not in props:
-                props["A:calendar-color"] = "#%x" % randint(0, 255 ** 3 - 1)
-            return props["A:calendar-color"]
+            if "ICAL:calendar-color" not in props:
+                props["ICAL:calendar-color"] = "#%x" % randint(0, 255 ** 3 - 1)
+            return props["ICAL:calendar-color"]
 
     @property
     def headers(self):

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -49,7 +49,6 @@ from . import client, config, ical
 
 
 NAMESPACES = {
-    "A": "http://apple.com/ns/ical/",
     "C": "urn:ietf:params:xml:ns:caldav",
     "CR": "urn:ietf:params:xml:ns:carddav",
     "D": "DAV:",
@@ -228,7 +227,7 @@ def propfind(path, xml_request, collections, user=None):
                  _tag("D", "displayname"),
                  _tag("D", "owner"),
                  _tag("D", "getetag"),
-                 _tag("A", "calendar-color"),
+                 _tag("ICAL", "calendar-color"),
                  _tag("CS", "getctag")]
 
     # Writing answer
@@ -343,7 +342,7 @@ def _propfind_response(path, item, props, user):
                     item.tag, item.headers, item.timezones)
             elif tag == _tag("D", "displayname"):
                 element.text = item.name
-            elif tag == _tag("A", "calendar-color"):
+            elif tag == _tag("ICAL", "calendar-color"):
                 element.text = item.color
             else:
                 human_tag = _tag_from_clark(tag)


### PR DESCRIPTION
5f2245c35fae introduced an additional alias for the
http://apple.com/ns/ical namespace. This can cause problems.

I'm not able to set colors reliably without this fix.
Apple Calendar always (on re-sync) reverts to the initial random colors.
