### PR TITLE
Allow full path in custom_handler config

### DIFF
--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -24,6 +24,7 @@ Authentication management.
 """
 
 import sys
+import imp
 
 from .. import config, log
 
@@ -36,8 +37,7 @@ def load():
         return None
     elif auth_type == 'custom':
         auth_module = config.get("auth", "custom_handler")
-        __import__(auth_module)
-        module = sys.modules[auth_module]
+        module = imp.load_source('radicale.auth.Custom', auth_module)
     else:
         root_module = __import__(
             "auth.%s" % auth_type, globals=globals(), level=2)

--- a/radicale/rights/__init__.py
+++ b/radicale/rights/__init__.py
@@ -24,6 +24,7 @@ configuration.
 
 """
 import sys
+import imp
 
 from .. import config
 
@@ -33,8 +34,7 @@ def load():
     storage_type = config.get("rights", "type")
     if storage_type == "custom":
         rights_module = config.get("rights", "custom_handler")
-        __import__(rights_module)
-        module = sys.modules[rights_module]
+        module = imp.load_source('radicale.rights.Custom', rights_module)
     else:
         root_module = __import__("rights.regex", globals=globals(), level=2)
         module = root_module.regex

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -23,7 +23,7 @@ This module loads the storage backend, according to the storage
 configuration.
 
 """
-import sys
+import imp
 from .. import config, ical
 
 
@@ -32,8 +32,7 @@ def load():
     storage_type = config.get("storage", "type")
     if storage_type == "custom":
         storage_module = config.get("storage", "custom_handler")
-        __import__(storage_module)
-        module = sys.modules[storage_module]
+        module = imp.load_source('radicale.storage.Custom', storage_module)
     else:
         root_module = __import__(
             "storage.%s" % storage_type, globals=globals(), level=2)


### PR DESCRIPTION
Use imp module to load custom handlers from arbitrary paths, so it
doesn't need to be in the PYTHONPATH.