### PR TITLE
change GET response from GONE to NOT FOUND when item is not found

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -423,7 +423,7 @@ class Application(object):
                     collection.tag, collection.headers, items)
                 etag = item.etag
             else:
-                return client.GONE, {}, None
+                return client.NOT_FOUND, {}, None
         else:
             # Create the collection if it does not exist
             if not collection.exists:


### PR DESCRIPTION
I think "GONE" is really a bad return code. It's really little used in real world because it implies keeping track of deleted items which 99% of server don't do, and its semantic is the same as 404 and means no real difference to clients.
As Radicale doesn't keep track of deleted items and only knows that they are not found, I strongly suggest to replace GONE with NOT FOUND :)