### PR TITLE
Use path for git commit message

### DIFF
--- a/radicale/storage/filesystem.py
+++ b/radicale/storage/filesystem.py
@@ -55,7 +55,7 @@ def open(path, mode="r"):
         path = os.path.relpath(abs_path, FOLDER)
         GIT_REPOSITORY.stage([path])
         committer = config.get("git", "committer")
-        GIT_REPOSITORY.do_commit("Commit by Radicale", committer=committer)
+        GIT_REPOSITORY.do_commit(path, committer=committer)
 # pylint: enable=W0622
 
 


### PR DESCRIPTION
The hard-coded message isn't very helpful, and that info is shown by the
author when looking at single line logs.