### PR TITLE
Improve Git commits

### DIFF
--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -341,7 +341,9 @@ class Collection(object):
                     item_lines = []
 
             if in_item:
-                item_lines.append(line)
+                # Thow away PRODID to minimize diff between modifications
+                if not line.startswith("PRODID:"):
+                    item_lines.append(line)
                 if line.startswith("END:%s" % item_tag):
                     in_item = False
                     item_type = item_tags[item_tag]

--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -44,7 +44,17 @@ def serialize(tag, headers=(), items=()):
     """
     items = sorted(items, key=lambda x: x.name)
     if tag == "VADDRESSBOOK":
-        lines = [item.text for item in items]
+        lines = []
+        for item in items:
+            def textcmp(x, y):
+                if x.startswith("BEGIN:") or y.startswith("END:"):
+                    return -1
+                elif x.startswith("END:") or y.startswith("BEGIN:"):
+                    return 1
+                else:
+                    return cmp(x, y)
+
+            lines.append("\n".join(sorted(item.text.splitlines(), cmp=textcmp)))
     else:
         lines = ["BEGIN:%s" % tag]
         for part in (headers, items):

--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -45,7 +45,7 @@ def serialize(tag=None, headers=(), items=()):
     collection delimiters.
 
     """
-    items = sorted(items, key=lambda x: x.name)
+    items = sorted(items, key=lambda x: (x.name, x.text))
 
     # Helper to sort item texts while preserving the position of BEGIN: and END: lines
     def sortitem(text):

--- a/radicale/storage/filesystem.py
+++ b/radicale/storage/filesystem.py
@@ -44,7 +44,7 @@ except:
 # This function overrides the builtin ``open`` function for this module
 # pylint: disable=W0622
 @contextmanager
-def open(path, mode="r"):
+def open(path, mode="r", commitmessage=None):
     """Open a file at ``path`` with encoding set in the configuration."""
     # On enter
     abs_path = os.path.join(FOLDER, path.replace("/", os.sep))
@@ -55,7 +55,8 @@ def open(path, mode="r"):
         path = os.path.relpath(abs_path, FOLDER)
         GIT_REPOSITORY.stage([path])
         committer = config.get("git", "committer")
-        GIT_REPOSITORY.do_commit(path, committer=committer)
+        commitmessage = commitmessage or path
+        GIT_REPOSITORY.do_commit(commitmessage, committer=committer)
 # pylint: enable=W0622
 
 
@@ -76,9 +77,9 @@ class Collection(ical.Collection):
         if not os.path.exists(os.path.dirname(self._path)):
             os.makedirs(os.path.dirname(self._path))
 
-    def save(self, text):
+    def save(self, text, message=None):
         self._create_dirs()
-        with open(self._path, "w") as fd:
+        with open(self._path, "w", commitmessage = message) as fd:
             fd.write(text)
 
     def delete(self):


### PR DESCRIPTION
This PR is a resurrection and extension of the outdated #183.

It changes replace() to be actually implemented instead of composing remove() and append(), so that it performs not two independent but a single, concise transaction on the storage backend. This is generally more efficient and especially desirable when Git support is enabled.

It also makes the commit messages slightly more informative and reduces the amount of changes in each commit by sorting fields and removing PRODID beforehand.