### PR TITLE
Use PAM service

### DIFF
--- a/radicale/auth/PAM.py
+++ b/radicale/auth/PAM.py
@@ -81,7 +81,7 @@ def is_authenticated(user, password):
             "The PAM user belongs to the required group (%s)" %
             GROUP_MEMBERSHIP)
         # Check the password
-        if pam_authenticate(user, password):
+        if pam_authenticate(user, password, service='radicale'):
             return True
         else:
             log.LOGGER.debug("Wrong PAM password")


### PR DESCRIPTION
This allows authentication types to be customised for radicale.