### PR TITLE
Secure path handling

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -32,7 +32,6 @@ import os
 import sys
 import pprint
 import base64
-import posixpath
 import socket
 import ssl
 import wsgiref.simple_server
@@ -48,7 +47,7 @@ except ImportError:
     from urlparse import urlparse
 # pylint: enable=F0401,E0611
 
-from . import auth, config, ical, log, rights, storage, xmlutils
+from . import auth, config, ical, log, pathutils, rights, storage, xmlutils
 
 
 VERSION = "1.0.1"
@@ -179,15 +178,7 @@ class Application(object):
     def sanitize_uri(uri):
         """Unquote and make absolute to prevent access to other data."""
         uri = unquote(uri)
-        trailing_slash = "/" if uri.endswith("/") else ""
-        uri = posixpath.normpath(uri)
-        new_uri = "/"
-        for part in uri.split("/"):
-            if not part or part in (".", ".."):
-                continue
-            new_uri = posixpath.join(new_uri, part)
-        trailing_slash = "" if new_uri.endswith("/") else trailing_slash
-        return new_uri + trailing_slash
+        return pathutils.sanitize_path(uri)
 
     def collect_allowed_items(self, items, user):
         """Get items from request that user is allowed to access."""

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -265,7 +265,9 @@ class Application(object):
             # Request path not starting with base_prefix, not allowed
             log.LOGGER.debug(
                 "Path not starting with prefix: %s", environ["PATH_INFO"])
-            environ["PATH_INFO"] = None
+            status, headers, _ = NOT_ALLOWED
+            start_response(status, list(headers.items()))
+            return []
 
         # Sanitize request URI
         environ["PATH_INFO"] = self.sanitize_uri(environ["PATH_INFO"])

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -177,12 +177,17 @@ class Application(object):
 
     @staticmethod
     def sanitize_uri(uri):
-        """Unquote and remove /../ to prevent access to other data."""
+        """Unquote and make absolute to prevent access to other data."""
         uri = unquote(uri)
         trailing_slash = "/" if uri.endswith("/") else ""
         uri = posixpath.normpath(uri)
-        trailing_slash = "" if uri == "/" else trailing_slash
-        return uri + trailing_slash
+        new_uri = "/"
+        for part in uri.split("/"):
+            if not part or part in (".", ".."):
+                continue
+            new_uri = posixpath.join(new_uri, part)
+        trailing_slash = "" if new_uri.endswith("/") else trailing_slash
+        return new_uri + trailing_slash
 
     def collect_allowed_items(self, items, user):
         """Get items from request that user is allowed to access."""

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -254,20 +254,22 @@ class Application(object):
         headers = pprint.pformat(self.headers_log(environ))
         log.LOGGER.debug("Request headers:\n%s" % headers)
 
+        # Strip base_prefix from request URI
         base_prefix = config.get("server", "base_prefix")
         if environ["PATH_INFO"].startswith(base_prefix):
-            # Sanitize request URI
-            environ["PATH_INFO"] = self.sanitize_uri(
-                "/%s" % environ["PATH_INFO"][len(base_prefix):])
-            log.LOGGER.debug("Sanitized path: %s", environ["PATH_INFO"])
+            environ["PATH_INFO"] = environ["PATH_INFO"][len(base_prefix):]
         elif config.get("server", "can_skip_base_prefix"):
             log.LOGGER.debug(
-                "Skipped already sanitized path: %s", environ["PATH_INFO"])
+                "Prefix already stripped from path: %s", environ["PATH_INFO"])
         else:
             # Request path not starting with base_prefix, not allowed
             log.LOGGER.debug(
                 "Path not starting with prefix: %s", environ["PATH_INFO"])
             environ["PATH_INFO"] = None
+
+        # Sanitize request URI
+        environ["PATH_INFO"] = self.sanitize_uri(environ["PATH_INFO"])
+        log.LOGGER.debug("Sanitized path: %s", environ["PATH_INFO"])
 
         path = environ["PATH_INFO"]
 

--- a/radicale/ical.py
+++ b/radicale/ical.py
@@ -26,12 +26,13 @@ Define the main classes of a collection as seen from the server.
 """
 
 import os
-import posixpath
 import hashlib
 import re
 from uuid import uuid4
 from random import randint
 from contextlib import contextmanager
+
+from . import pathutils
 
 
 def serialize(tag, headers=(), items=()):
@@ -183,8 +184,9 @@ class Collection(object):
 
         """
         self.encoding = "utf-8"
-        split_path = path.split("/")
-        self.path = path if path != "." else ""
+        # path should already be sanitized
+        self.path = pathutils.sanitize_path(path).strip("/")
+        split_path = self.path.split("/")
         if principal and split_path and self.is_node(self.path):
             # Already existing principal collection
             self.owner = split_path[0]
@@ -215,8 +217,8 @@ class Collection(object):
         if path is None:
             return []
 
-        # First do normpath and then strip, to prevent access to FOLDER/../
-        sane_path = posixpath.normpath(path.replace(os.sep, "/")).strip("/")
+        # path should already be sanitized
+        sane_path = pathutils.sanitize_path(path).strip("/")
         attributes = sane_path.split("/")
         if not attributes:
             return []

--- a/radicale/pathutils.py
+++ b/radicale/pathutils.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Radicale Server - Calendar Server
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Helper functions for working with paths
+
+"""
+
+import posixpath
+
+
+def sanitize_path(path):
+    """Make absolute (with leading slash) to prevent access to other data.
+       Preserves an potential trailing slash."""
+    trailing_slash = "/" if path.endswith("/") else ""
+    path = posixpath.normpath(path)
+    new_path = "/"
+    for part in path.split("/"):
+        if not part or part in (".", ".."):
+            continue
+        new_path = posixpath.join(new_path, part)
+    trailing_slash = "" if new_path.endswith("/") else trailing_slash
+    return new_path + trailing_slash

--- a/radicale/pathutils.py
+++ b/radicale/pathutils.py
@@ -40,6 +40,18 @@ def sanitize_path(path):
     return new_path + trailing_slash
 
 
+def is_safe_path_component(path):
+    """Checks if path is a single component of a path and is safe to join"""
+    if not path:
+        return False
+    head, _ = posixpath.split(path)
+    if head:
+        return False
+    if path in (".", ".."):
+        return False
+    return True
+
+
 def is_safe_filesystem_path_component(path):
     """Checks if path is a single component of a local filesystem path
        and is safe to join"""

--- a/radicale/pathutils.py
+++ b/radicale/pathutils.py
@@ -20,7 +20,10 @@ Helper functions for working with paths
 
 """
 
+import os
 import posixpath
+
+from . import log
 
 
 def sanitize_path(path):
@@ -35,3 +38,35 @@ def sanitize_path(path):
         new_path = posixpath.join(new_path, part)
     trailing_slash = "" if new_path.endswith("/") else trailing_slash
     return new_path + trailing_slash
+
+
+def is_safe_filesystem_path_component(path):
+    """Checks if path is a single component of a local filesystem path
+       and is safe to join"""
+    if not path:
+        return False
+    drive, _ = os.path.splitdrive(path)
+    if drive:
+        return False
+    head, _ = os.path.split(path)
+    if head:
+        return False
+    if path in (os.curdir, os.pardir):
+        return False
+    return True
+
+
+def path_to_filesystem(path, base_folder):
+    """Converts path to a local filesystem path relative to base_folder
+        in a secure manner or raises ValueError."""
+    sane_path = sanitize_path(path).strip("/")
+    safe_path = base_folder
+    if not sane_path:
+        return safe_path
+    for part in sane_path.split("/"):
+        if not is_safe_filesystem_path_component(part):
+            log.LOGGER.debug("Can't translate path safely to filesystem: %s",
+                             path)
+            raise ValueError("Unsafe path")
+        safe_path = os.path.join(safe_path, part)
+    return safe_path

--- a/radicale/storage/filesystem.py
+++ b/radicale/storage/filesystem.py
@@ -29,7 +29,7 @@ import time
 import sys
 from contextlib import contextmanager
 
-from .. import config, ical, pathutils
+from .. import config, ical, log, pathutils
 
 
 FOLDER = os.path.expanduser(config.get("storage", "filesystem_folder"))
@@ -100,6 +100,12 @@ class Collection(ical.Collection):
         filesystem_path = pathutils.path_to_filesystem(path, FOLDER)
         _, directories, files = next(os.walk(filesystem_path))
         for filename in directories + files:
+            # make sure that the local filename can be translated
+            # into an internal path
+            if not pathutils.is_safe_path_component(filename):
+                log.LOGGER.debug("Skipping unsupported filename: %s",
+                                 filename)
+                continue
             rel_filename = posixpath.join(path, filename)
             if cls.is_node(rel_filename) or cls.is_leaf(rel_filename):
                 yield cls(rel_filename)

--- a/radicale/storage/multifilesystem.py
+++ b/radicale/storage/multifilesystem.py
@@ -30,13 +30,14 @@ import sys
 from . import filesystem
 from .. import ical
 from .. import log
+from .. import pathutils
 
 
 class Collection(filesystem.Collection):
     """Collection stored in several files per calendar."""
     def _create_dirs(self):
-        if not os.path.exists(self._path):
-            os.makedirs(self._path)
+        if not os.path.exists(self._filesystem_path):
+            os.makedirs(self._filesystem_path)
 
     @property
     def headers(self):
@@ -52,17 +53,18 @@ class Collection(filesystem.Collection):
             name = (
                 component.name if sys.version_info[0] >= 3 else
                 component.name.encode(filesystem.FILESYSTEM_ENCODING))
-            path = os.path.join(self._path, name)
-            with filesystem.open(path, "w") as fd:
+            filesystem_path = os.path.join(self._filesystem_path, name)
+            with filesystem.open(filesystem_path, "w") as fd:
                 fd.write(text)
 
     def delete(self):
-        shutil.rmtree(self._path)
+        shutil.rmtree(self._filesystem_path)
         os.remove(self._props_path)
 
     def remove(self, name):
-        if os.path.exists(os.path.join(self._path, name)):
-            os.remove(os.path.join(self._path, name))
+        filesystem_path = os.path.join(self._filesystem_path, name)
+        if os.path.exists(filesystem_path):
+            os.remove(filesystem_path)
 
     @property
     def text(self):
@@ -70,14 +72,14 @@ class Collection(filesystem.Collection):
             ical.Timezone, ical.Event, ical.Todo, ical.Journal, ical.Card)
         items = set()
         try:
-            filenames = os.listdir(self._path)
+            filenames = os.listdir(self._filesystem_path)
         except (OSError, IOError) as e:
             log.LOGGER.info('Error while reading collection %r: %r'
-                            % (self._path, e))
+                            % (self._filesystem_path, e))
             return ""
 
         for filename in filenames:
-            path = os.path.join(self._path, filename)
+            path = os.path.join(self._filesystem_path, filename)
             try:
                 with filesystem.open(path) as fd:
                     items.update(self._parse(fd.read(), components))
@@ -90,17 +92,21 @@ class Collection(filesystem.Collection):
 
     @classmethod
     def is_node(cls, path):
-        path = os.path.join(filesystem.FOLDER, path.replace("/", os.sep))
-        return os.path.isdir(path) and not os.path.exists(path + ".props")
+        filesystem_path = pathutils.path_to_filesystem(path,
+                                                       filesystem.FOLDER)
+        return (os.path.isdir(filesystem_path) and
+                not os.path.exists(filesystem_path + ".props"))
 
     @classmethod
     def is_leaf(cls, path):
-        path = os.path.join(filesystem.FOLDER, path.replace("/", os.sep))
-        return os.path.isdir(path) and os.path.exists(path + ".props")
+        filesystem_path = pathutils.path_to_filesystem(path,
+                                                       filesystem.FOLDER)
+        return (os.path.isdir(filesystem_path) and
+                os.path.exists(path + ".props"))
 
     @property
     def last_modified(self):
         last = max([
-            os.path.getmtime(os.path.join(self._path, filename))
-            for filename in os.listdir(self._path)] or [0])
+            os.path.getmtime(os.path.join(self._filesystem_path, filename))
+            for filename in os.listdir(self._filesystem_path)] or [0])
         return time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime(last))

--- a/radicale/storage/multifilesystem.py
+++ b/radicale/storage/multifilesystem.py
@@ -53,6 +53,11 @@ class Collection(filesystem.Collection):
             name = (
                 component.name if sys.version_info[0] >= 3 else
                 component.name.encode(filesystem.FILESYSTEM_ENCODING))
+            if not pathutils.is_safe_filesystem_path_component(name):
+                log.LOGGER.debug(
+                    "Can't tranlate name safely to filesystem, "
+                    "skipping component: %s", name)
+                continue
             filesystem_path = os.path.join(self._filesystem_path, name)
             with filesystem.open(filesystem_path, "w") as fd:
                 fd.write(text)
@@ -62,6 +67,11 @@ class Collection(filesystem.Collection):
         os.remove(self._props_path)
 
     def remove(self, name):
+        if not pathutils.is_safe_filesystem_path_component(name):
+            log.LOGGER.debug(
+                "Can't tranlate name safely to filesystem, "
+                "skipping component: %s", name)
+            return
         filesystem_path = os.path.join(self._filesystem_path, name)
         if os.path.exists(filesystem_path):
             os.remove(filesystem_path)


### PR DESCRIPTION
This fixes a number of issues with dodgy path handling:

  * Paths like ``..``, ``../..`` or ``//`` are not sanitized correctly
  * The program crashes if a path doesn't start with ``base_prefix`` instead of showing an error message
  * On MS Windows the filesystem backend allows access to the first level of files on a drive.
    
    e.g. the path ``/c:/filename/dummy`` gets converted to ``c:\filename``
  * The multifilesystem backend allows access to arbitrary files on all platforms.

    e.g. set the UID of a ics file to ``/dev/null``