### PR TITLE
New parameter "user_strip_at" to remove @domain from user.

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -280,6 +280,11 @@ class Application(object):
             user = environ.get("REMOTE_USER")
             password = None
 
+        if user is not None and config.getboolean("auth", "user_strip_at"):
+            m = re.match('(\w+)@', user)
+            if m is not None:
+                user = m.group(1)
+
         well_known = WELL_KNOWN_RE.match(path)
         if well_known:
             redirect = config.get("well-known", well_known.group(1))

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -76,7 +76,8 @@ INITIAL_CONFIG = {
         "courier_socket": "",
         "http_url": "",
         "http_user_parameter": "",
-        "http_password_parameter": ""},
+        "http_password_parameter": "",
+        "user_strip_at": "False"},
     "git": {
         "committer": "Radicale <radicale@example.com>"},
     "rights": {


### PR DESCRIPTION
Given a user who configures some clients using a userid and others using an email address, probably because of the clients' differing user interfaces, we found it simplest just to strip the domain from the email address to just use the userid (as they matched) as per this patch.

Comments?