### PR TITLE
Fix privilege set for read only collection

### DIFF
--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -45,7 +45,7 @@ except ImportError:
 import re
 import xml.etree.ElementTree as ET
 
-from . import client, config, ical
+from . import client, config, ical, rights
 
 
 NAMESPACES = {
@@ -300,11 +300,13 @@ def _propfind_response(path, item, props, user):
             element.append(tag)
         elif tag == _tag("D", "current-user-privilege-set"):
             privilege = ET.Element(_tag("D", "privilege"))
-            privilege.append(ET.Element(_tag("D", "all")))
+            if rights.authorized(user, item, "w"):
+                privilege.append(ET.Element(_tag("D", "all")))
             privilege.append(ET.Element(_tag("D", "read")))
-            privilege.append(ET.Element(_tag("D", "write")))
-            privilege.append(ET.Element(_tag("D", "write-properties")))
-            privilege.append(ET.Element(_tag("D", "write-content")))
+            if rights.authorized(user, item, "w"):
+                privilege.append(ET.Element(_tag("D", "write")))
+                privilege.append(ET.Element(_tag("D", "write-properties")))
+                privilege.append(ET.Element(_tag("D", "write-content")))
             element.append(privilege)
         elif tag == _tag("D", "supported-report-set"):
             for report_name in (


### PR DESCRIPTION
When server responses to PROPFIND request for a collection it doesn't check access rights for the collection and send full set of privileges: all, read, write, write-properties, write-content. This patch add rights check and server will response accordingly.

```
2016-03-04 09:03:38,714 - DEBUG: Reading rights from file /srv/radicale/rights
2016-03-04 09:03:38,721 - DEBUG: Test if 'alyabev:alyabev/kollegi.vcf' matches against '^daver$:.*' from section 'admin'
2016-03-04 09:03:38,721 - DEBUG: Test if 'alyabev:alyabev/kollegi.vcf' matches against '.+:^alyabev/kollegi.vcf$' from section 'common'
2016-03-04 09:03:38,721 - DEBUG: Section 'common' matches
2016-03-04 09:03:38,721 - DEBUG: alyabev has read access to collection alyabev/kollegi.vcf/
2016-03-04 09:03:38,722 - DEBUG: Reading rights from file /srv/radicale/rights
2016-03-04 09:03:38,725 - DEBUG: Test if 'alyabev:alyabev/kollegi.vcf' matches against '^daver$:.*' from section 'admin'
2016-03-04 09:03:38,726 - DEBUG: Test if 'alyabev:alyabev/kollegi.vcf' matches against '.+:^alyabev/kollegi.vcf$' from section 'common'
2016-03-04 09:03:38,726 - DEBUG: Section 'common' matches
2016-03-04 09:03:38,726 - DEBUG: alyabev has NO write access to collection alyabev/kollegi.vcf/
2016-03-04 09:03:38,726 - DEBUG: Request content:
<?xml version="1.0" encoding="UTF-8"?>
<A:propfind xmlns:A="DAV:">
  <A:prop>
    <A:add-member/>
    <D:bulk-requests xmlns:D="http://me.com/_namespace/"/>
    <A:current-user-privilege-set/>
    <A:displayname/>
    <B:max-image-size xmlns:B="urn:ietf:params:xml:ns:carddav"/>
    <B:max-resource-size xmlns:B="urn:ietf:params:xml:ns:carddav"/>
    <C:me-card xmlns:C="http://calendarserver.org/ns/"/>
    <A:owner/>
    <C:push-transports xmlns:C="http://calendarserver.org/ns/"/>
    <C:pushkey xmlns:C="http://calendarserver.org/ns/"/>
    <A:quota-available-bytes/>
    <A:quota-used-bytes/>
    <A:resource-id/>
    <A:resourcetype/>
    <A:supported-report-set/>
    <A:sync-token/>
  </A:prop>
</A:propfind>

2016-03-04 09:03:38,751 - DEBUG: Response content:
<?xml version="1.0"?>
<multistatus xmlns="DAV:" xmlns:CR="urn:ietf:params:xml:ns:carddav" xmlns:CS="http://calendarserver.org/ns/" xmlns:ME="http://me.com/_namespace/">
  <response>
    <href>/alyabev/kollegi.vcf/</href>
    <propstat>
      <prop>
        <current-user-privilege-set>
          <privilege>
            <all />
            <read />
            <write />
            <write-properties />
            <write-content />
          </privilege>
        </current-user-privilege-set>
        <displayname>kollegi.vcf</displayname>
        <owner>/alyabev/</owner>
        <resourcetype>
          <CR:addressbook />
          <collection />
        </resourcetype>
        <supported-report-set>
          <supported-report>
            <report>principal-property-search</report>
          </supported-report>
          <supported-report>
            <report>sync-collection</report>
          </supported-report>
          <supported-report>
            <report>expand-property</report>
          </supported-report>
          <supported-report>
            <report>principal-search-property-set</report>
          </supported-report>
        </supported-report-set>
      </prop>
      <status>HTTP/1.1 200 OK</status>
    </propstat>
    <propstat>
      <prop>
        <add-member />
        <ME:bulk-requests />
        <CR:max-image-size />
        <CR:max-resource-size />
        <CS:me-card />
        <CS:push-transports />
        <CS:pushkey />
        <quota-available-bytes />
        <quota-used-bytes />
        <resource-id />
        <sync-token />
      </prop>
      <status>HTTP/1.1 404 Not Found</status>
    </propstat>
  </response>
```