### PR TITLE
Add umask configuration option

### DIFF
--- a/config
+++ b/config
@@ -165,6 +165,9 @@
 # Folder for storing local collections, created if not present
 #filesystem_folder = ~/.config/radicale/collections
 
+# Umask for files created by Radicale
+#umask =
+
 # Database URL for SQLAlchemy
 # dialect+driver://user:password@host/dbname[?key=value..]
 # For example: sqlite:///var/db/radicale.db, postgresql://user:password@localhost/radicale

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -124,6 +124,9 @@ def run():
             os.dup2(null_out.fileno(), sys.stdout.fileno())
             os.dup2(null_out.fileno(), sys.stderr.fileno())
 
+    if config.get("storage", "umask"):
+        os.umask(int(config.get("storage", "umask")));
+
     # Register exit function
     def cleanup():
         """Remove the PID files."""

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -81,7 +81,8 @@ INITIAL_CONFIG = {
         "custom_handler": "",
         "filesystem_folder": os.path.expanduser(
             "~/.config/radicale/collections"),
-        "database_url": ""},
+        "database_url": "",
+        "umask": ""},
     "logging": {
         "config": "/etc/radicale/logging",
         "debug": "False",


### PR DESCRIPTION
The possibility to configure the `umask` for files created by Radicale makes ugly wrapper scripts à la `umask xyz && radicale` obsolete.

Also, in daemon-mode it was previously not possible to influence the umask (it's [hardcoded to 0](https://github.com/sherter/Radicale/blob/87aec8c29d30cbcbd1c18dd73684fe813f2d5ece/radicale/__main__.py#L118)). 