### PR TITLE
Fix double slash in REPORT responses

### DIFF
--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -565,7 +565,7 @@ def report(path, xml_request, collection):
             # TODO: fix this
             if hreference.split("/")[-1] == item.href:
                 # Happening when depth is 0
-                uri = "/" + hreference
+                uri = hreference
             else:
                 # Happening when depth is 1
                 uri = posixpath.join(hreference, item.href)


### PR DESCRIPTION
When doing REPORTs with absolute paths as hrefs, the response hrefs
contain a double slash at the beginning. This breaks URL parsers and
makes them assume they have a URL without protocol of the format
`//example.com/foo/bar/`.

I'd rather replace the entire statement with `uri = hreference` as
prepending the doubleslash seems unnecessary, but I haven't tested with
other request input.