### PR TITLE
Fix etag generation

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -60,7 +60,7 @@ MIMETYPES = {"VADDRESSBOOK": "text/vcard", "VCALENDAR": "text/calendar"}
 def get_etag(text):
     """Etag from collection or item."""
     etag = md5()
-    etag.update(text.encode("utf-8"))
+    etag.update(u'\r\n'.join(text.splitlines()).encode("utf-8"))
     return '"%s"' % etag.hexdigest()
 
 


### PR DESCRIPTION
When PUTting an item, Radicale will:

* Store the text byte-for-byte
* Hash the text and return the etag

However, when fetching the item, Radicale will:

* Parse the text with the vobject library
* Serialize the text for output
* Derive the etag from the serialized text

When PUTting an item with UNIX-style lineendings, Radicale will return
the hash for the item with UNIX-style lineendings. However, when
fetching items, the UNIX-style lineendings are repaired and Radicale
returns a different etag.

A good idea would be to spare the vobject serialization/deserialization
roundtrip as it doesn't seem necessary, but this bug can also be fixed
by making the `get_etag` function indifferent towards various
lineendings.