### PR TITLE
Implement locking of whole storage

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -282,45 +282,37 @@ class Application:
         is_authenticated = self.is_authenticated(user, password)
         is_valid_user = is_authenticated or not user
 
-        lock = None
-        try:
-            if is_valid_user:
-                if function in (self.do_GET, self.do_HEAD,
-                                self.do_OPTIONS, self.do_PROPFIND,
-                                self.do_REPORT):
-                    lock_mode = "r"
-                else:
-                    lock_mode = "w"
-                lock = self.Collection.acquire_lock(lock_mode)
+        # Get content
+        content_length = int(environ.get("CONTENT_LENGTH") or 0)
+        if content_length:
+            content = self.decode(
+                environ["wsgi.input"].read(content_length), environ)
+            self.logger.debug("Request content:\n%s" % content)
+        else:
+            content = None
 
+        if is_valid_user:
+            if function in (self.do_GET, self.do_HEAD,
+                            self.do_OPTIONS, self.do_PROPFIND,
+                            self.do_REPORT):
+                lock_mode = "r"
+            else:
+                lock_mode = "w"
+            with self.Collection.acquire_lock(lock_mode):
                 items = self.Collection.discover(
                     path, environ.get("HTTP_DEPTH", "0"))
                 read_allowed_items, write_allowed_items = (
                     self.collect_allowed_items(items, user))
-            else:
-                read_allowed_items, write_allowed_items = None, None
-
-            # Get content
-            content_length = int(environ.get("CONTENT_LENGTH") or 0)
-            if content_length:
-                content = self.decode(
-                    environ["wsgi.input"].read(content_length), environ)
-                self.logger.debug("Request content:\n%s" % content)
-            else:
-                content = None
-
-            if is_valid_user and (
-                    (read_allowed_items or write_allowed_items) or
-                    (is_authenticated and function == self.do_PROPFIND) or
-                    function == self.do_OPTIONS):
-                status, headers, answer = function(
-                    environ, read_allowed_items, write_allowed_items, content,
-                    user)
-            else:
-                status, headers, answer = NOT_ALLOWED
-        finally:
-            if lock:
-                lock.release()
+                if (read_allowed_items or write_allowed_items or
+                        is_authenticated and function == self.do_PROPFIND or
+                        function == self.do_OPTIONS):
+                    status, headers, answer = function(
+                        environ, read_allowed_items, write_allowed_items,
+                        content, user)
+                else:
+                    status, headers, answer = NOT_ALLOWED
+        else:
+            status, headers, answer = NOT_ALLOWED
 
         if (status, headers, answer) == NOT_ALLOWED and not is_authenticated:
             # Unknown or unauthorized user

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -30,6 +30,7 @@ import os
 import pprint
 import base64
 import socket
+import socketserver
 import ssl
 import wsgiref.simple_server
 import re
@@ -90,6 +91,14 @@ class HTTPSServer(HTTPServer):
 
         self.server_bind()
         self.server_activate()
+
+
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
+    pass
+
+
+class ThreadedHTTPSServer(socketserver.ThreadingMixIn, HTTPSServer):
+    pass
 
 
 class RequestHandler(wsgiref.simple_server.WSGIRequestHandler):

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -33,7 +33,8 @@ import ssl
 from wsgiref.simple_server import make_server
 
 from . import (
-    Application, config, HTTPServer, HTTPSServer, log, RequestHandler, VERSION)
+    Application, config, ThreadedHTTPServer, ThreadedHTTPSServer, log,
+    RequestHandler, VERSION)
 
 
 # This is a script, many branches and variables
@@ -152,7 +153,7 @@ def run():
     # Create collection servers
     servers = {}
     if configuration.getboolean("server", "ssl"):
-        server_class = HTTPSServer
+        server_class = ThreadedHTTPSServer
         server_class.certificate = configuration.get("server", "certificate")
         server_class.key = configuration.get("server", "key")
         server_class.cyphers = configuration.get("server", "cyphers")
@@ -168,7 +169,7 @@ def run():
                     "Error while reading SSL %s %r: %s" % (
                         name, filename, exception))
     else:
-        server_class = HTTPServer
+        server_class = ThreadedHTTPServer
 
     if not configuration.getboolean("server", "dns_lookup"):
         RequestHandler.address_string = lambda self: self.client_address[0]

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -277,13 +277,12 @@ class BaseCollection:
         raise NotImplementedError
 
     @classmethod
+    @contextmanager
     def acquire_lock(cls, mode):
-        """Lock the whole storage.
+        """Set a context manager to lock the whole storage.
 
         ``mode`` must either be "r" for shared access or "w" for exclusive
         access.
-
-        Returns an object which has a method ``release``.
 
         """
         raise NotImplementedError
@@ -521,6 +520,7 @@ class Collection(BaseCollection):
     _lock = threading.Lock()
 
     @classmethod
+    @contextmanager
     def acquire_lock(cls, mode):
         class Lock:
             def __init__(self, release_method):
@@ -574,4 +574,5 @@ class Collection(BaseCollection):
             # TODO: use readers–writer lock
             cls._lock.acquire()
             lock = Lock(cls._lock.release)
-        return lock
+        yield
+        lock.release()

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -92,6 +92,7 @@ def load(configuration, logger):
 
 
 MIMETYPES = {"VADDRESSBOOK": "text/vcard", "VCALENDAR": "text/calendar"}
+MAX_FILE_LOCK_DURATION = 0.25
 
 
 def get_etag(text):
@@ -528,6 +529,7 @@ class Collection(BaseCollection):
     _waiters = []
     _lock_file = None
     _lock_file_locked = False
+    _lock_file_time = 0
     _readers = 0
     _writer = False
 
@@ -535,6 +537,11 @@ class Collection(BaseCollection):
     @contextmanager
     def acquire_lock(cls, mode):
         def condition():
+            # Prevent starvation of writers in other processes
+            if cls._lock_file_locked:
+                time_delta = time.time() - cls._lock_file_time
+                if time_delta < 0 or time_delta > MAX_FILE_LOCK_DURATION:
+                    return False
             if mode == "r":
                 return not cls._writer
             else:
@@ -588,6 +595,7 @@ class Collection(BaseCollection):
                     except OSError:
                         cls.logger.debug("Locking not supported")
                 cls._lock_file_locked = True
+                cls._lock_file_time = time.time()
         yield
         with cls._lock:
             if mode == "r":


### PR DESCRIPTION
Added method ``acquire_lock`` to ``BaseCollection`` which locks the whole storage for shared or exclusive access. In the default backend file locking is used to implement this method.
Unfortunately file locking is a bit broken and doesn't work in some cases, see comments.
This is not the most efficient method (all requests which potentially write to the storage are serialized) but it's simple.
For higher performance an transaction based approach would be great but that's difficult to implement on a raw filesystem and a database backend should be used.

I also enabled threading in the integrated webserver, this should resolve issues like #388.