### PR TITLE
Veify Authorization Scheme

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -251,8 +251,8 @@ class Application:
         # Ask authentication backend to check rights
         authorization = environ.get("HTTP_AUTHORIZATION", None)
 
-        if authorization:
-            authorization = authorization.lstrip("Basic").strip()
+        if authorization and authorization.startswith("Basic"):
+            authorization = authorization[len("Basic"):].strip()
             user, password = self.decode(base64.b64decode(
                 authorization.encode("ascii")), environ).split(":", 1)
         else:


### PR DESCRIPTION
This should at least partially fix #338.
Outllok 2016 sends "Bearer" in the Authorization header to show OAuth support or something.