### PR TITLE
Save all items with the same UID in the same file

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -380,12 +380,25 @@ class Collection(BaseCollection):
                         for oitem in items[i+1:]:
                             if getattr(oitem, "uid", None) == uid:
                                 new_collection.add(oitem)
-                    self.upload(uuid4().hex, new_collection)
+                    if uid and is_safe_filesystem_path_component(uid.value):
+                        href = uid.value
+                    else:
+                        href = uuid4().hex
+                    if not href.lower().endswith(".ics"):
+                        href += ".ics"
+                    self.upload(href, new_collection)
         elif tag == "VCARD":
             self.set_meta("tag", "VADDRESSBOOK")
             if collection:
                 for card in collection:
-                    self.upload(uuid4().hex, card)
+                    uid = getattr(card, "uid", None)
+                    if uid and is_safe_filesystem_path_component(uid.value):
+                        href = uid.value
+                    else:
+                        href = uuid4().hex
+                    if not href.lower().endswith(".vcf"):
+                        href += ".vcf"
+                    self.upload(href, card)
         return self
 
     def list(self):

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -364,12 +364,23 @@ class Collection(BaseCollection):
             self.set_meta("tag", "VCALENDAR")
             if collection:
                 collection, = collection
+                items = []
                 for content in ("vevent", "vtodo", "vjournal"):
-                    if content in collection.contents:
-                        for item in getattr(collection, "%s_list" % content):
-                            new_collection = vobject.iCalendar()
-                            new_collection.add(item)
-                            self.upload(uuid4().hex, new_collection)
+                    items.extend(getattr(collection, "%s_list" % content, []))
+                processed_uids = []
+                for i, item in enumerate(items):
+                    uid = getattr(item, "uid", None)
+                    if uid in processed_uids:
+                        continue
+                    new_collection = vobject.iCalendar()
+                    new_collection.add(item)
+                    if uid:
+                        processed_uids.append(uid)
+                        # search for items with same UID
+                        for oitem in items[i+1:]:
+                            if getattr(oitem, "uid", None) == uid:
+                                new_collection.add(oitem)
+                    self.upload(uuid4().hex, new_collection)
         elif tag == "VCARD":
             self.set_meta("tag", "VADDRESSBOOK")
             if collection:


### PR DESCRIPTION
  - If recurrences are not in the same file, they are not correctly shown by clients.
  -  Try to use UID as filename
