### PR TITLE
Add hook for storage changes

### DIFF
--- a/config
+++ b/config
@@ -112,6 +112,10 @@
 # Folder for storing local collections, created if not present
 #filesystem_folder = ~/.config/radicale/collections
 
+# Command that is run after changes to storage
+#hook =
+# Example: git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)
+
 
 [logging]
 

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -30,10 +30,12 @@ import os
 import pprint
 import base64
 import contextlib
+import shlex
 import socket
 import socketserver
 import ssl
 import threading
+import subprocess
 import wsgiref.simple_server
 import re
 import zlib
@@ -348,6 +350,15 @@ class Application:
                     status, headers, answer = function(
                         environ, read_allowed_items, write_allowed_items,
                         content, user)
+                    hook = self.configuration.get("storage", "hook")
+                    if lock_mode == "w" and hook:
+                        self.logger.debug("Running hook")
+                        folder = os.path.expanduser(
+                            self.configuration.get("storage",
+                                                   "filesystem_folder"))
+                        subprocess.check_call(
+                            hook % {"user": shlex.quote(user or "Anonymous")},
+                            shell=True, cwd=folder)
                 else:
                     status, headers, answer = NOT_ALLOWED
         else:

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -60,7 +60,8 @@ INITIAL_CONFIG = {
     "storage": {
         "type": "multifilesystem",
         "filesystem_folder": os.path.expanduser(
-            "~/.config/radicale/collections")},
+            "~/.config/radicale/collections"),
+        "hook": ""},
     "logging": {
         "config": "/etc/radicale/logging",
         "debug": "False",


### PR DESCRIPTION
This allows easy integration of external version control tools. (#372, #327)

Example:
```
hook = git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)
```

This is also a possible solution to #289:

Example:
```
hook = rm calendars/all/*; cp calendars/*/* calendars/all; true