### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,21 +17,10 @@ RUN apk --update --update-cache upgrade \
 
 RUN pip3 install passlib bcrypt
 
-RUN mkdir -p /data/config
 RUN wget ${TARBALL} \
     && tar xzf ${VERSION}.tar.gz \
     && cd Radicale-${VERSION} && python3 setup.py install
 
-COPY config /data/config
+COPY config /srv/radicale.conf
 
-# User
-RUN adduser -h /home/radicale -D radicale \
-      && mkdir -p /home/radicale/.config \
-      && ln -s /data/config /home/radicale/.config/radicale \
-      && chown -R radicale:radicale /data/config \
-      && chown -R radicale:radicale /home/radicale
-
-USER radicale
-WORKDIR /home/radicale
-
-CMD ["radicale", "-D", "-C", "/data/config/config"]
+CMD ["radicale", "-D", "-C", "/srv/radicale.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,33 +2,40 @@
 #
 # VERSION 0.3.1
 
-FROM 	alpine:latest
+FROM alpine:latest
 
 # Base packages
-RUN	apk update && \
-	apk upgrade && \
-	apk add python3 python3-dev build-base libffi-dev ca-certificates
+RUN apk update \
+      && apk upgrade \
+      && apk add \
+          python3 \
+          python3-dev \
+          build-base \
+          libffi-dev \
+          ca-certificates
 
 # Python installation
 # pip
-ADD	https://bootstrap.pypa.io/get-pip.py /tmp/install/
-RUN	python3 /tmp/install/* && \
-	pip install passlib bcrypt setuptools
+ADD https://bootstrap.pypa.io/get-pip.py /tmp/install/
+RUN python3 /tmp/install/* && \
+      pip install passlib bcrypt setuptools
 
 # Radicale installation
-RUN	mkdir -p /data/config
-COPY 	. /data/radicale
-COPY	config /data/config
-RUN	cd /data/radicale && python3 setup.py install
+RUN mkdir -p /data/config
+
+COPY . /data/radicale
+COPY config /data/config
+
+RUN cd /data/radicale && python3 setup.py install
 
 # User
-RUN 	adduser -h /home/radicale -D radicale && \
-	mkdir -p /home/radicale/.config && \
- 	ln -s /data/config /home/radicale/.config/radicale && \
- 	chown -R radicale:radicale /data/config && \
-	chown -R radicale:radicale /home/radicale
+RUN adduser -h /home/radicale -D radicale \
+      && mkdir -p /home/radicale/.config \
+      && ln -s /data/config /home/radicale/.config/radicale \
+      && chown -R radicale:radicale /data/config \
+      && chown -R radicale:radicale /home/radicale
 
-USER 	radicale
-WORKDIR	/home/radicale
+USER radicale
+WORKDIR /home/radicale
 
-CMD 	["radicale", "-D", "-C", "/data/config/config"]
+CMD ["radicale", "-D", "-C", "/data/config/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM alpine:latest
 
+MAINTAINER Radicale project "radicale@librelist.com"
+
 # Base packages
 RUN apk update \
       && apk upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@ RUN apk --update --update-cache upgrade \
           python3-dev \
           build-base \
           libffi-dev \
-          ca-certificates
+          ca-certificates \
+      && python3 -m ensurepip \
+      && pip3 install --upgrade pip
 
 # Python installation
 # pip
-ADD https://bootstrap.pypa.io/get-pip.py /tmp/install/
-RUN python3 /tmp/install/* && \
-      pip install passlib bcrypt setuptools
+RUN pip3 install passlib bcrypt setuptools
 
 # Radicale installation
 RUN mkdir -p /data/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-# Radicale Dockerfile
-#
-# VERSION 0.3.1
-
 FROM alpine:latest
 
 MAINTAINER Radicale project "radicale@librelist.com"
 
-# Base packages
 RUN apk --update --update-cache upgrade \
       && apk add \
           python3 \
@@ -17,11 +12,8 @@ RUN apk --update --update-cache upgrade \
       && python3 -m ensurepip \
       && pip3 install --upgrade pip
 
-# Python installation
-# pip
 RUN pip3 install passlib bcrypt setuptools
 
-# Radicale installation
 RUN mkdir -p /data/config
 
 COPY . /data/radicale

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ FROM alpine:latest
 MAINTAINER Radicale project "radicale@librelist.com"
 
 # Base packages
-RUN apk update \
-      && apk upgrade \
+RUN apk --update --update-cache upgrade \
       && apk add \
           python3 \
           python3-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:latest
 
 MAINTAINER Radicale project "radicale@librelist.com"
 
+ENV VERSION 1.1.1
+ENV TARBALL https://github.com/Kozea/Radicale/archive/${VERSION}.tar.gz
+
 RUN apk --update --update-cache upgrade \
       && apk add \
           python3 \
@@ -12,14 +15,14 @@ RUN apk --update --update-cache upgrade \
       && python3 -m ensurepip \
       && pip3 install --upgrade pip
 
-RUN pip3 install passlib bcrypt setuptools
+RUN pip3 install passlib bcrypt
 
 RUN mkdir -p /data/config
+RUN wget ${TARBALL} \
+    && tar xzf ${VERSION}.tar.gz \
+    && cd Radicale-${VERSION} && python3 setup.py install
 
-COPY . /data/radicale
 COPY config /data/config
-
-RUN cd /data/radicale && python3 setup.py install
 
 # User
 RUN adduser -h /home/radicale -D radicale \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN wget ${TARBALL} \
     && mkdir -p /etc/radicale \
     && cp config /etc/radicale/config
 
-CMD ["radicale", "-D", "-C", "/etc/radicale/config"]
+CMD ["radicale", "-f", "-D", "-C", "/etc/radicale/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apk --update --update-cache upgrade \
 
 RUN wget ${TARBALL} \
     && tar xzf ${VERSION}.tar.gz \
-    && cd Radicale-${VERSION} && python3 setup.py install
+    && cd Radicale-${VERSION} && python3 setup.py install \
+    && mkdir -p /etc/radicale \
+    && cp config /etc/radicale/config
 
-COPY config /srv/radicale.conf
-
-CMD ["radicale", "-D", "-C", "/srv/radicale.conf"]
+CMD ["radicale", "-D", "-C", "/etc/radicale/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN wget ${TARBALL} \
 
 EXPOSE 5232
 
-CMD ["radicale", "-f", "-D", "-C", "/etc/radicale/config"]
+CMD ["radicale", "-f", "-C", "/etc/radicale/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,8 @@ RUN apk --update --update-cache upgrade \
           libffi-dev \
           ca-certificates \
       && python3 -m ensurepip \
-      && pip3 install --upgrade pip
-
-RUN pip3 install passlib bcrypt
+      && pip3 install --upgrade pip \
+      && pip3 install passlib bcrypt
 
 RUN wget ${TARBALL} \
     && tar xzf ${VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,6 @@ RUN wget ${TARBALL} \
     && mkdir -p /etc/radicale \
     && cp config /etc/radicale/config
 
+EXPOSE 5232
+
 CMD ["radicale", "-f", "-D", "-C", "/etc/radicale/config"]


### PR DESCRIPTION
This PR brings a lot of modifications to the existing Dockerfile, with the aim of improving it by making it more compliant to best practices and de-facto usages.
I know this PR contains huge modifications splitted in several commits; I've done this so it can be reviewed in an iterative "step by step" way, and am open to squashing it if you prefer to.

I'm also, of course, open to any suggestion/comment about it and don't want to force anything :)
I'll describe more in details the modifications below.

## Style

### Indentation/Alignment

The Dockerfile has been modified to make it more consistent with the official Dockerfiles (regarding purely style things such as tabs, alignment, etc), like for example the [nginx one](https://github.com/nginxinc/docker-nginx/blob/11fc019b2be3ad51ba5d097b1857a099c4056213/mainline/jessie/Dockerfile).

### Comments

I took the liberty in my rework to remove superfluous comments; a Dockerfile is, most of the time, self-explanatory.

## Directives

The Dockerfile was lacking a [MAINTAINER](https://docs.docker.com/engine/reference/builder/#maintainer) directive; I added one refering to the project and its mailing list.

I also added an [EXPOSE](https://docs.docker.com/engine/reference/builder/#expose) directive to make explicit the fact that it's listening on port 5232.

## Dependancies

- The dependancies handling part (apk and pip) have been merged in an unique layer
- apk commands have been merged as much as possible
- pip is installed from the dedicated built-in module of python3

## Sources

While directly COPY-ing sources is perfectly fine for projects delivering Docker images to the [Docker Hub](https://hub.docker.com/) with automated build, I think that in Radicale's case it would benefit from being more easily buildable by everyone.

The COPY of the sources have therefore been replaced by a direct download of the latest release from GitHub, which is then extracted and installed. Future releases will only need to update the "VERSION" variable.

## Radicale Configuration

With the same logic as sources, configuration is now directly taken from the sources already present in the image, and copied to a [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) compliant and [already documented](http://radicale.org/user_documentation/#idmain-configuration-file) path instead of `/data` : `/etc/radicale/config`

### -f

Even if it seems to be already the default behavior right now, I added the -f option to the command to make sure Radicale runs in foreground.

## Conclusion

I'm already using this reworked Dockerfile to run my own Radicale server and it's working fine.
If this PR gets accepted, I'm also willing to add a part about running Radicale in Docker in the documentation, if you're OK with this.