### PR TITLE
Split the main run function to allow the use of radicale serving programatically. 

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -107,6 +107,11 @@ def run():
     if not configuration_found:
         logger.warning("Configuration file '%s' not found" % options.config)
 
+    serve(configuration, logger)
+
+
+def serve(configuration, logger):
+    """Serve radicale from configuration"""
     # Fork if Radicale is launched as daemon
     if configuration.getboolean("server", "daemon"):
         # Check and create PID file in a race-free manner

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -65,12 +65,16 @@ INITIAL_CONFIG = {
         "mask_passwords": "True"}}
 
 
-def load(paths=()):
+def load(paths=(), extra_config=None):
     config = ConfigParser()
     for section, values in INITIAL_CONFIG.items():
         config.add_section(section)
         for key, value in values.items():
             config.set(section, key, value)
+    if extra_config:
+        for section, values in extra_config.items():
+            for key, value in values.items():
+                config.set(section, key, value)
     for path in paths:
         if path:
             config.read(path)


### PR DESCRIPTION
Also add an `extra_config` parameter to the config `load` to override config.