### PR TITLE
Always match full username/collection with regex

### DIFF
--- a/radicale/rights.py
+++ b/radicale/rights.py
@@ -66,7 +66,7 @@ permission:rw
     "owner_write": """
 [w]
 user:.+
-collection:^%(login)s(/.*)?$
+collection:%(login)s(/.*)?
 permission:rw
 [r]
 user:.+
@@ -76,7 +76,7 @@ permission:r
     "owner_only": """
 [rw]
 user:.+
-collection:^%(login)s(/.*)?$
+collection:%(login)s(/.*)?
 permission:rw
     """}
 
@@ -127,10 +127,10 @@ class Rights(BaseRights):
             self.logger.debug(
                 "Test if '%s:%s' matches against '%s:%s' from section '%s'" % (
                     user, collection_url, re_user, re_collection, section))
-            user_match = re.match(re_user, user)
+            user_match = re.fullmatch(re_user, user)
             if user_match:
                 re_collection = re_collection.format(*user_match.groups())
-                if re.match(re_collection, collection_url):
+                if re.fullmatch(re_collection, collection_url):
                     self.logger.debug("Section '%s' matches" % section)
                     return permission in regex.get(section, "permission")
                 else:

--- a/rights
+++ b/rights
@@ -14,7 +14,7 @@
 
 # This means all users starting with "admin" may read any collection
 [admin]
-user: ^admin.*$
+user: admin.*
 collection: .*
 permission: r
 
@@ -22,14 +22,14 @@ permission: r
 # We do so by just not testing against the user string.
 [public]
 user: .*
-collection: ^public(/.+)?$
+collection: public(/.+)?
 permission: rw
 
 # A little more complex: give read access to users from a domain for all
 # collections of all the users (ie. user@domain.tld can read domain/*).
 [domain-wide-access]
-user: ^.+@(.+)\..+$
-collection: ^{0}/.+$
+user: .+@(.+)\..+
+collection: {0}/.+
 permission: r
 
 # Allow authenticated user to read all collections
@@ -41,5 +41,5 @@ permission: r
 # Give write access to owners
 [owner-write]
 user: .+
-collection: ^%(login)s/.*$
+collection: %(login)s/.*
 permission: w


### PR DESCRIPTION
It's easy to forget $ at the end of a regex and it's counter-intuitive that ^ is implicit but $ is not.