### PR TITLE
Creating addressbooks and calendars in DAVdroid

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -355,25 +355,27 @@ class Collection(BaseCollection):
         # path should already be sanitized
         sane_path = sanitize_path(path).strip("/")
         attributes = sane_path.split("/")
-        if not attributes:
-            return
+        if not attributes[0]:
+            attributes.pop()
 
         # Try to guess if the path leads to a collection or an item
         folder = os.path.expanduser(
             cls.configuration.get("storage", "filesystem_folder"))
         if not os.path.isdir(path_to_filesystem(folder, sane_path)):
             # path is not a collection
-            if os.path.isfile(path_to_filesystem(folder, sane_path)):
+            if attributes and os.path.isfile(path_to_filesystem(folder,
+                                                                sane_path)):
                 # path is an item
                 attributes.pop()
-            elif os.path.isdir(path_to_filesystem(folder, *attributes[:-1])):
+            elif attributes and os.path.isdir(path_to_filesystem(
+                    folder, *attributes[:-1])):
                 # path parent is a collection
                 attributes.pop()
             # TODO: else: return?
 
         path = "/".join(attributes)
 
-        principal = len(attributes) <= 1
+        principal = len(attributes) == 1
         collection = cls(path, principal)
         yield collection
         if depth != "0":

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -590,14 +590,11 @@ def _propfind_response(path, item, props, user, write=False):
         is404 = False
         if tag == _tag("D", "getetag"):
             element.text = item.etag
-        elif tag == _tag("D", "principal-URL"):
-            tag = ET.Element(_tag("D", "href"))
-            tag.text = _href(collection, path)
-            element.append(tag)
         elif tag == _tag("D", "getlastmodified"):
             element.text = item.last_modified
         elif tag in (_tag("D", "principal-collection-set"),
                      _tag("C", "calendar-user-address-set"),
+                     _tag("D", "principal-URL"),
                      _tag("CR", "addressbook-home-set"),
                      _tag("C", "calendar-home-set")):
             tag = ET.Element(_tag("D", "href"))

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -592,8 +592,11 @@ def _propfind_response(path, item, props, user, write=False):
             element.text = item.etag
         elif tag == _tag("D", "getlastmodified"):
             element.text = item.last_modified
-        elif tag in (_tag("D", "principal-collection-set"),
-                     _tag("C", "calendar-user-address-set"),
+        elif tag == _tag("D", "principal-collection-set"):
+            tag = ET.Element(_tag("D", "href"))
+            tag.text = _href(collection, "/")
+            element.append(tag)
+        elif tag in (_tag("C", "calendar-user-address-set"),
                      _tag("D", "principal-URL"),
                      _tag("CR", "addressbook-home-set"),
                      _tag("C", "calendar-home-set")):

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -596,10 +596,11 @@ def _propfind_response(path, item, props, user, write=False):
             tag = ET.Element(_tag("D", "href"))
             tag.text = _href(collection, "/")
             element.append(tag)
-        elif tag in (_tag("C", "calendar-user-address-set"),
-                     _tag("D", "principal-URL"),
-                     _tag("CR", "addressbook-home-set"),
-                     _tag("C", "calendar-home-set")):
+        elif (tag in (_tag("C", "calendar-user-address-set"),
+                      _tag("D", "principal-URL"),
+                      _tag("CR", "addressbook-home-set"),
+                      _tag("C", "calendar-home-set")) and
+                collection.is_principal):
             tag = ET.Element(_tag("D", "href"))
             tag.text = _href(collection, path)
             element.append(tag)


### PR DESCRIPTION
This fixes some issues that prevent creation of collections in DAVdroid from working smoothly.

The first problem is that the properties **addressbook-home-set** and **calendar-home-set** are returned on _/_ with a value of _/_.
The second problem is that the principal collection doesn't exist for new users.

This is also related to #384.