### PR TITLE
Durable creation of directories and make sure that the root colleciton exists.

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -433,7 +433,6 @@ class Collection(BaseCollection):
         if not attributes[0]:
             attributes.pop()
 
-        # Try to guess if the path leads to a collection or an item
         folder = cls._get_collection_root_folder()
         # Create the root collection
         cls._makedirs_synced(folder, exist_ok=True)
@@ -443,6 +442,7 @@ class Collection(BaseCollection):
             # Path is unsafe
             return
 
+        # Check if the path exists and if it leads to a collection or an item
         if not os.path.isdir(filesystem_path):
             if attributes and os.path.isfile(filesystem_path):
                 href = attributes.pop()

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -262,6 +262,8 @@ class BaseCollection:
 
         The ``path`` is relative.
 
+        The root collection "/" must always exist.
+
         """
         raise NotImplementedError
 
@@ -433,6 +435,8 @@ class Collection(BaseCollection):
 
         # Try to guess if the path leads to a collection or an item
         folder = cls._get_collection_root_folder()
+        # Create the root collection
+        cls._makedirs_synced(folder, exist_ok=True)
         try:
             filesystem_path = path_to_filesystem(folder, sane_path)
         except ValueError:


### PR DESCRIPTION
This makes sure that all created directories are synced to disk.
Before #457 the root collection was created by ``Collection.acquire_lock`` and before #459 it didn't matter if the folder existed or not.