### PR TITLE
Atomic MOVE

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -473,8 +473,6 @@ class Application:
         to_path = storage.sanitize_path(to_url.path)
         if not self._access(user, to_path, "w"):
             return NOT_ALLOWED
-        if to_path.strip("/").startswith(path.strip("/")):
-            return client.CONFLICT, {}, None
 
         with self._lock_collection("w", user):
             item = next(self.Collection.discover(path), None)

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -496,12 +496,7 @@ class Application:
             if not to_collection:
                 return client.CONFLICT, {}, None
             to_href = posixpath.basename(to_path.strip("/"))
-            if path.strip("/") != to_path.strip("/"):
-                if to_item:
-                    to_collection.update(to_href, item.item)
-                else:
-                    to_collection.upload(to_href, item.item)
-                item.collection.delete(item.href)
+            self.Collection.move(item, to_collection, to_href)
             return client.CREATED, {}, None
 
     def do_OPTIONS(self, environ, path, content, user):

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -265,6 +265,26 @@ class BaseCollection:
         """
         raise NotImplementedError
 
+    @classmethod
+    def move(cls, item, to_collection, to_href):
+        """Move an object.
+
+        ``item`` is the item to move.
+
+        ``to_collection`` is the target collection.
+
+        ``to_href`` is the target name in ``to_collection``. An item with the
+        same name might already exist.
+
+        """
+        if item.collection.path == to_collection.path and item.href == to_href:
+            return
+        if to_collection.has(to_href):
+            to_collection.update(to_href, item.item)
+        else:
+            to_collection.upload(to_href, item.item)
+        item.collection.delete(item.href)
+
     @property
     def etag(self):
         return get_etag(self.serialize())

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -534,6 +534,15 @@ class Collection(BaseCollection):
 
         return cls(sane_path, principal=principal)
 
+    @classmethod
+    def move(cls, item, to_collection, to_href):
+        os.rename(
+            path_to_filesystem(item.collection._filesystem_path, item.href),
+            path_to_filesystem(to_collection._filesystem_path, to_href))
+        sync_directory(to_collection._filesystem_path)
+        if item.collection._filesystem_path != to_collection._filesystem_path:
+            sync_directory(item.collection._filesystem_path)
+
     def list(self):
         try:
             hrefs = os.listdir(self._filesystem_path)


### PR DESCRIPTION
This makes the MOVE operation atomic and also adds the ability to overwrite items if the **Overwrite** header is set.

MOVE and DELETE are the only remaining operations that are not atomic. This gets fixed by #453 and this PR. All changes besides creation of intermediate collections (which gets fixed by #462) are synced to disk during requests (at least on Linux and MacOS). Calendars and addressbooks should now be pretty safe with Radicale.