### PR TITLE
Set correct path for child collections

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -497,8 +497,9 @@ class Collection(BaseCollection):
                 continue
             child_filesystem_path = path_to_filesystem(filesystem_path, href)
             if os.path.isdir(child_filesystem_path):
+                child_path = posixpath.join(path, href)
                 child_principal = len(attributes) == 0
-                yield cls(child_filesystem_path, child_principal)
+                yield cls(child_path, child_principal)
 
     @classmethod
     def create_collection(cls, href, collection=None, props=None):

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -541,7 +541,8 @@ def _propfind_response(path, item, props, user, write=False):
 
     href = ET.Element(_tag("D", "href"))
     if is_collection:
-        uri = item.path
+        # Some clients expect collections to end with /
+        uri = item.path + "/"
     else:
         # TODO: fix this
         if path.split("/")[-1] == item.href:


### PR DESCRIPTION
This also adds a test for PROPFIND. In general we need more tests to catch stupid mistakes like this.