### PR TITLE
Create predefined calendars and addressbooks for new users

### DIFF
--- a/config
+++ b/config
@@ -113,6 +113,13 @@
 # Example: git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)
 
 
+[skel]
+
+# Collections that are created for new users separated by a comma
+#addressbooks = addressbook.vcf
+#calendars = calendar.ics
+
+
 [logging]
 
 # Logging configuration file

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -287,8 +287,7 @@ class Application:
             if self.authorized(user, principal_path, "w"):
                 with self._lock_collection("r", user):
                     principal = next(
-                        self.Collection.discover(principal_path, depth="1"),
-                        None)
+                        self.Collection.discover(principal_path), None)
                 if not principal:
                     with self._lock_collection("w", user):
                         self.Collection.create_collection(principal_path)

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -290,7 +290,7 @@ class Application:
                         self.Collection.discover(principal_path), None)
                 if not principal:
                     with self._lock_collection("w", user):
-                        self.Collection.create_collection(principal_path)
+                        self.Collection.create_user(user)
 
         # Verify content length
         content_length = int(environ.get("CONTENT_LENGTH") or 0)

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -61,6 +61,9 @@ INITIAL_CONFIG = {
         "fsync": "True",
         "hook": "",
         "close_lock_file": "False"},
+    "skel": {
+        "addressbooks": "addressbook.vcf",
+        "calendars": "calendar.ics"},
     "logging": {
         "config": "/etc/radicale/logging",
         "debug": "False",

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -398,9 +398,8 @@ class BaseCollection:
 class Collection(BaseCollection):
     """Collection stored in several files per calendar."""
 
-    def __init__(self, path, principal=False, folder=None):
-        if not folder:
-            folder = self._get_collection_root_folder()
+    def __init__(self, path, principal=False):
+        folder = self._get_collection_root_folder()
         # Path should already be sanitized
         self.path = sanitize_path(path).strip("/")
         self.encoding = self.configuration.get("encoding", "stock")
@@ -568,7 +567,12 @@ class Collection(BaseCollection):
             # The temporary directory itself can't be renamed
             tmp_filesystem_path = os.path.join(tmp_dir, "collection")
             os.makedirs(tmp_filesystem_path)
-            self = cls("/", principal=principal, folder=tmp_filesystem_path)
+            class ClsTmpCollectionRootFolder(cls):
+                @staticmethod
+                def _get_collection_root_folder():
+                    return tmp_filesystem_path
+
+            self = ClsTmpCollectionRootFolder("/", principal=principal)
             self.set_meta(props)
 
             if collection:

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -539,6 +539,26 @@ class Collection(BaseCollection):
                 yield cls(child_path, child_principal)
 
     @classmethod
+    def create_user(cls, user):
+        # Create principal collection in temporary directory and rename,
+        # when all predefined collections are created.
+        principal_path = "/%s/" % user
+        if not user or next(cls.discover(principal_path), None):
+            return
+        folder = cls._get_collection_root_folder()
+        with TemporaryDirectory(
+                prefix=".Radicale.tmp-", dir=folder) as tmp_dir:
+            class ClsTmpCollectionRootFolder(cls):
+                @staticmethod
+                def _get_collection_root_folder():
+                    return tmp_dir
+
+            super(Collection, ClsTmpCollectionRootFolder).create_user(user)
+            os.rename(path_to_filesystem(tmp_dir, user),
+                      path_to_filesystem(folder, user))
+            sync_directory(folder)
+
+    @classmethod
     def create_collection(cls, href, collection=None, props=None):
         folder = cls._get_collection_root_folder()
 

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -556,7 +556,7 @@ class Collection(BaseCollection):
             super(Collection, ClsTmpCollectionRootFolder).create_user(user)
             os.rename(path_to_filesystem(tmp_dir, user),
                       path_to_filesystem(folder, user))
-            sync_directory(folder)
+            cls._sync_directory(folder)
 
     @classmethod
     def create_collection(cls, href, collection=None, props=None):

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -736,6 +736,13 @@ class BaseRequestsMixIn:
             "GET", "/user/", REMOTE_USER="user")
         assert status == 200
 
+    def test_creation_of_predefined_collections(self):
+        self.request("GET", "/", REMOTE_USER="user")
+        status, headers, answer = self.request("GET", "/user/calendar.ics/")
+        assert status == 200
+        status, headers, answer = self.request("GET", "/user/addressbook.vcf/")
+        assert status == 200
+
     def test_existence_of_root_collections(self):
         """Verify that the root collection always exists."""
         # Use PROPFIND because GET returns message


### PR DESCRIPTION
The administrator can define a list of collections (calendars and addressbooks) in the config file that are created for new users. This is especially useful for clients that don't support the creation of collections.