### PR TITLE
Add option to disable syncing to disk

### DIFF
--- a/config
+++ b/config
@@ -103,6 +103,11 @@
 # Folder for storing local collections, created if not present
 #filesystem_folder = ~/.config/radicale/collections
 
+# Sync all changes to disk during requests. (This can impair performance.)
+# Disabling it increases the risk of data loss, when the system crashes or
+# power fails!
+#fsync = True
+
 # Command that is run after changes to storage
 #hook =
 # Example: git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -58,6 +58,7 @@ INITIAL_CONFIG = {
         "type": "multifilesystem",
         "filesystem_folder": os.path.expanduser(
             "~/.config/radicale/collections"),
+        "fsync": "True",
         "hook": ""},
     "logging": {
         "config": "/etc/radicale/logging",

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -711,6 +711,8 @@ class TestMultiFileSystem(BaseRequests, BaseTest):
         super().setup()
         self.colpath = tempfile.mkdtemp()
         self.configuration.set("storage", "filesystem_folder", self.colpath)
+        # Disable syncing to disk for better performance
+        self.configuration.set("storage", "fsync", "False")
         self.application = Application(self.configuration, self.logger)
 
     def teardown(self):
@@ -725,6 +727,8 @@ class TestCustomStorageSystem(BaseRequests, BaseTest):
         super().setup()
         self.colpath = tempfile.mkdtemp()
         self.configuration.set("storage", "filesystem_folder", self.colpath)
+        # Disable syncing to disk for better performance
+        self.configuration.set("storage", "fsync", "False")
         self.application = Application(self.configuration, self.logger)
 
     def teardown(self):

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     packages=["radicale"],
     provides=["radicale"],
     scripts=["bin/radicale"],
-    install_requires=["vobject", "atomicwrites"],
+    install_requires=["vobject"],
     setup_requires=pytest_runner,
     tests_require=[
         "pytest-runner", "pytest-cov", "pytest-flake8", "pytest-isort"],


### PR DESCRIPTION
Disabling syncing increases the risk of data loss when the system crashes or power fails. On the positive side it can increase the performance to a great extent.

I disabled fsync for the tests, which reduces the test time by almost 70% (at least on my system).