### PR TITLE
Add option to close lock file

### DIFF
--- a/radicale/config.py
+++ b/radicale/config.py
@@ -59,7 +59,8 @@ INITIAL_CONFIG = {
         "filesystem_folder": os.path.expanduser(
             "~/.config/radicale/collections"),
         "fsync": "True",
-        "hook": ""},
+        "hook": "",
+        "close_lock_file": "False"},
     "logging": {
         "config": "/etc/radicale/logging",
         "debug": "False",

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -802,3 +802,7 @@ class Collection(BaseCollection):
                     cls._lock_file_locked = False
                 if cls._waiters:
                     cls._waiters[0].notify()
+                if (cls.configuration.getboolean("storage", "close_lock_file")
+                        and cls._readers == 0 and not cls._waiters):
+                    cls._lock_file.close()
+                    cls._lock_file = None

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -813,6 +813,8 @@ class BaseFileSystemTest(BaseTest):
         self.configuration.set("storage", "filesystem_folder", self.colpath)
         # Disable syncing to disk for better performance
         self.configuration.set("storage", "fsync", "False")
+        # Required on Windows, doesn't matter on Unix
+        self.configuration.set("storage", "close_lock_file", "True")
         self.application = Application(self.configuration, self.logger)
 
     def teardown(self):


### PR DESCRIPTION
Close the lock file, when no more clients are waiting.
This option is not very useful in general, but on Windows files that are opened cannot be deleted. This causes tests to fail, because the deletion of the temporary filesystem folder fails.