### PR TITLE
Ask for authentication if current-user-principal is requested

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -532,9 +532,12 @@ class Application:
             items = itertools.chain([item], items)
             read_items, write_items = self.collect_allowed_items(items, user)
             headers = {"DAV": DAV_HEADERS, "Content-Type": "text/xml"}
-            answer = xmlutils.propfind(
+            status, answer = xmlutils.propfind(
                 path, content, read_items, write_items, user)
-            return client.MULTI_STATUS, headers, answer
+            if status == client.FORBIDDEN:
+                return NOT_ALLOWED
+            else:
+                return status, headers, answer
 
     def do_PROPPATCH(self, environ, path, user):
         """Manage PROPPATCH request."""

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -510,6 +510,12 @@ def propfind(path, xml_request, read_collections, write_collections, user):
             _tag("ICAL", "calendar-color"),
             _tag("CS", "getctag")]
 
+    if _tag("D", "current-user-principal") in props and not user:
+        # Ask for authentication
+        # Returning the DAV:unauthenticated pseudo-principal as specified in
+        # RFC 5397 doesn't seem to work with DAVdroid.
+        return client.FORBIDDEN, None
+
     multistatus = ET.Element(_tag("D", "multistatus"))
     collections = []
     for collection in write_collections:

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -524,7 +524,7 @@ def propfind(path, xml_request, read_collections, write_collections, user):
             path, collection, props, user, write=False)
         multistatus.append(response)
 
-    return _pretty_xml(multistatus)
+    return client.MULTI_STATUS, _pretty_xml(multistatus)
 
 
 def _propfind_response(path, item, props, user, write=False):


### PR DESCRIPTION
DAVdroid dropped support for preemptive authentication in version 1.2.3. Currently it's impossible to login as a user.
Returning the DAV:unauthenticated pseudo-principal as specified in RFC 5397 doesn't work for DAVdroid (or maybe I was just doing something wrong).
