### PR TITLE
 Revert 1ffc171

### DIFF
--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -581,7 +581,7 @@ def _propfind_response(path, item, props, user, write=False):
                       _tag("D", "principal-URL"),
                       _tag("CR", "addressbook-home-set"),
                       _tag("C", "calendar-home-set")) and
-                collection.is_principal):
+                collection.is_principal and is_collection):
             tag = ET.Element(_tag("D", "href"))
             tag.text = _href(collection, path)
             element.append(tag)

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -577,7 +577,11 @@ def _propfind_response(path, item, props, user, write=False):
             tag = ET.Element(_tag("D", "href"))
             tag.text = _href(collection, "/")
             element.append(tag)
-        elif tag == _tag("D", "principal-URL") and collection.is_principal:
+        elif (tag in (_tag("C", "calendar-user-address-set"),
+                      _tag("D", "principal-URL"),
+                      _tag("CR", "addressbook-home-set"),
+                      _tag("C", "calendar-home-set")) and
+                collection.is_principal):
             tag = ET.Element(_tag("D", "href"))
             tag.text = _href(collection, path)
             element.append(tag)
@@ -595,11 +599,7 @@ def _propfind_response(path, item, props, user, write=False):
                     element.append(comp)
             else:
                 is404 = True
-        elif tag in (
-                _tag("D", "current-user-principal"),
-                _tag("C", "calendar-user-address-set"),
-                _tag("CR", "addressbook-home-set"),
-                _tag("C", "calendar-home-set")):
+        elif tag == _tag("D", "current-user-principal"):
             tag = ET.Element(_tag("D", "href"))
             tag.text = _href(collection, ("/%s/" % user) if user else "/")
             element.append(tag)


### PR DESCRIPTION
Maybe I misunderstand the RFC, but this properties are related to a principal collection. DAVdroid without preemptive authentication doesn't like this and tries to create calendars and addressbooks in /.

This PR in combination with #480 fixes compatibility with DAVdroid 1.2.3.