### PR TITLE
Fix empty filter

### DIFF
--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -267,6 +267,9 @@ class BaseRequestsMixIn:
                </C:calendar-query>""" % filters_text)
         return answer
 
+    def test_calendar_empty_filter(self):
+        self._test_filter([""])
+
     def test_calendar_tag_filter(self):
         """Report request with tag-based filter on calendar."""
         assert "href>/calendar.ics/event1.ics</" in self._test_filter(["""

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -809,7 +809,8 @@ def report(path, xml_request, collection):
                 match = (
                     _comp_match if collection.get_meta("tag") == "VCALENDAR"
                     else _prop_match)
-                if not all(match(item, filter_[0]) for filter_ in filters):
+                if not all(match(item, filter_[0]) for filter_ in filters
+                           if filter_):
                     continue
 
             found_props = []


### PR DESCRIPTION
DAVdroid sends ``<CARD:filter />``, which causes an exception.