### PR TITLE
Optimize upload of whole collections

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -552,7 +552,7 @@ class Collection(BaseCollection):
                         items.extend(
                             getattr(collection, "%s_list" % content, []))
                     items_by_uid = groupby(sorted(items, key=get_uid), get_uid)
-                    collections = {}
+                    vobject_items = {}
                     for uid, items in items_by_uid:
                         new_collection = vobject.iCalendar()
                         for item in items:
@@ -561,14 +561,14 @@ class Collection(BaseCollection):
                         # Prevent infinite loop
                         for _ in range(10000):
                             href = self._find_available_file_name()
-                            if href not in collections:
+                            if href not in vobject_items:
                                 break
                         else:
                             raise FileExistsError(
                                 errno.EEXIST, "No usable file name found")
-                        collections[href] = new_collection
+                        vobject_items[href] = new_collection
 
-                    self.upload_all(collections)
+                    self.upload_all(vobject_items)
                 elif props.get("tag") == "VCARD":
                     for card in collection:
                         self.upload(self._find_available_file_name(), card)

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -562,8 +562,11 @@ class Collection(BaseCollection):
                         vobject_items[href] = new_collection
                     self.upload_all(vobject_items)
                 elif props.get("tag") == "VCARD":
+                    vobject_items = {}
                     for card in collection:
-                        self.upload(self._find_available_file_name(self.has), card)
+                        href = self._find_available_file_name(vobject_items.get)
+                        vobject_items[href] = card
+                    self.upload_all(vobject_items)
 
             # This operation is not atomic on the filesystem level but it's
             # very unlikely that one rename operations succeeds while the

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -560,13 +560,13 @@ class Collection(BaseCollection):
                             new_collection.add(item)
                         href = self._find_available_file_name(vobject_items.get)
                         vobject_items[href] = new_collection
-                    self.upload_all(vobject_items)
+                    self.upload_all_nonatomic(vobject_items)
                 elif props.get("tag") == "VCARD":
                     vobject_items = {}
                     for card in collection:
                         href = self._find_available_file_name(vobject_items.get)
                         vobject_items[href] = card
-                    self.upload_all(vobject_items)
+                    self.upload_all_nonatomic(vobject_items)
 
             # This operation is not atomic on the filesystem level but it's
             # very unlikely that one rename operations succeeds while the
@@ -578,7 +578,7 @@ class Collection(BaseCollection):
 
         return cls(sane_path, principal=principal)
 
-    def upload_all(self, vobject_items):
+    def upload_all_nonatomic(self, vobject_items):
         """Upload a new set of items.
 
         This takes a mapping of href and vobject items and

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -321,19 +321,6 @@ class BaseCollection:
         """Upload a new item."""
         raise NotImplementedError
 
-    def upload_all(self, vobject_items):
-        """Upload a new set of items.
-
-        This takes a mapping of href and vobject items and
-        returns a list of uploaded items.
-        Might bring optimizations on some storages.
-
-        """
-        return [
-            self.upload(href, vobject_item)
-            for href, vobject_item in vobject_items.items()
-        ]
-
     def update(self, href, vobject_item):
         """Update an item.
 
@@ -595,6 +582,19 @@ class Collection(BaseCollection):
             cls._sync_directory(parent_dir)
 
         return cls(sane_path, principal=principal)
+
+    def upload_all(self, vobject_items):
+        """Upload a new set of items.
+
+        This takes a mapping of href and vobject items and
+        returns a list of uploaded items.
+        Might bring optimizations on some storages.
+
+        """
+        return [
+            self.upload(href, vobject_item)
+            for href, vobject_item in vobject_items.items()
+        ]
 
     @classmethod
     def move(cls, item, to_collection, to_href):


### PR DESCRIPTION
This gets rid of the useless atomic creation of items inside a new temporary collection. Additionally all calls to fsync are bundled and the directory is only synced once.

Result from a simple speed test (addressbook with 1000 entries):
  * Before: 1:25 minutes
  * After: 0:05 minutes

I moved ``upload_all`` from ``BaseCollection`` to ``Collection`` because it's not used anywhere else and probably never will be as WebDAV doesn't support bulk uploads. Additionally I renamed it to ``upload_all_nonatomic`` to reflect it's new usage.