### PR TITLE
More secure external authentication

### DIFF
--- a/config
+++ b/config
@@ -83,6 +83,10 @@
 # Value: plain | sha1 | ssha | crypt | bcrypt | md5
 #htpasswd_encryption = crypt
 
+# Get users from the REMOTE_USER environment variable instead of
+  using HTTP authentication
+#remote_user = False
+
 
 [rights]
 

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -336,9 +336,10 @@ class Application:
             login, password = self.decode(base64.b64decode(
                 authorization.encode("ascii")), environ).split(":", 1)
             user = self.Auth.map_login_to_user(login)
+            is_authenticated = self.Auth.is_authenticated(user, password)
         else:
             user = self.Auth.map_login_to_user(environ.get("REMOTE_USER", ""))
-            password = None
+            is_authenticated = bool(user)
 
         # If "/.well-known" is not available, clients query "/"
         if path == "/.well-known" or path.startswith("/.well-known/"):
@@ -348,8 +349,6 @@ class Application:
             # Prevent usernames like "user/calendar.ics"
             self.logger.info("Refused unsafe username: %s", user)
             is_authenticated = False
-        else:
-            is_authenticated = self.Auth.is_authenticated(user, password)
         is_valid_user = is_authenticated or not user
 
         # Create principal collection

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -331,15 +331,14 @@ class Application:
 
         # Ask authentication backend to check rights
         authorization = environ.get("HTTP_AUTHORIZATION", None)
-        if authorization and authorization.startswith("Basic"):
+        login = password = ""
+        if self.configuration.getboolean("auth", "remote_user"):
+            login = environ.get("REMOTE_USER", "")
+        elif authorization and authorization.startswith("Basic"):
             authorization = authorization[len("Basic"):].strip()
             login, password = self.decode(base64.b64decode(
                 authorization.encode("ascii")), environ).split(":", 1)
-            user = self.Auth.map_login_to_user(login)
-            is_authenticated = self.Auth.is_authenticated(user, password)
-        else:
-            user = self.Auth.map_login_to_user(environ.get("REMOTE_USER", ""))
-            is_authenticated = bool(user)
+        user = self.Auth.map_login_to_user(login)
 
         # If "/.well-known" is not available, clients query "/"
         if path == "/.well-known" or path.startswith("/.well-known/"):
@@ -349,6 +348,8 @@ class Application:
             # Prevent usernames like "user/calendar.ics"
             self.logger.info("Refused unsafe username: %s", user)
             is_authenticated = False
+        else:
+            is_authenticated = self.Auth.is_authenticated(user, password)
         is_valid_user = is_authenticated or not user
 
         # Create principal collection
@@ -385,12 +386,14 @@ class Application:
                 user and is_authenticated):
             # Unknown or unauthorized user
             self.logger.info("%s refused" % (user or "Anonymous user"))
-            status = client.UNAUTHORIZED
-            realm = self.configuration.get("server", "realm")
-            headers = dict(headers)
-            headers.update ({
-                "WWW-Authenticate":
-                "Basic realm=\"%s\"" % realm})
+            # Only send authentication request if it's handled by radicale
+            if not self.configuration.getboolean("auth", "remote_user"):
+                status = client.UNAUTHORIZED
+                realm = self.configuration.get("server", "realm")
+                headers = dict(headers)
+                headers.update ({
+                    "WWW-Authenticate":
+                    "Basic realm=\"%s\"" % realm})
 
         return response(status, headers, answer)
 

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -50,7 +50,8 @@ INITIAL_CONFIG = {
     "auth": {
         "type": "None",
         "htpasswd_filename": "/etc/radicale/users",
-        "htpasswd_encryption": "crypt"},
+        "htpasswd_encryption": "crypt",
+        "remote_user": "False"},
     "rights": {
         "type": "None",
         "file": "~/.config/radicale/rights"},

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -776,6 +776,7 @@ class BaseRequestsMixIn:
 
     def test_principal_collection_creation(self):
         """Verify existence of the principal collection."""
+        self.configuration.set("auth", "remote_user", "True")
         status, headers, answer = self.request(
             "PROPFIND", "/user/", REMOTE_USER="user")
         assert status == 207
@@ -830,6 +831,7 @@ class BaseRequestsMixIn:
         self.configuration.set(
             "storage", "hook", "mkdir %s" % os.path.join("collection-root",
                                                          "created_by_hook"))
+        self.configuration.set("auth", "remote_user", "True")
         status, headers, answer = self.request("GET", "/", REMOTE_USER="user")
         assert status == 200
         status, headers, answer = self.request("PROPFIND", "/created_by_hook/")


### PR DESCRIPTION
It's unnecessary to check users from external authentication with ``is_authenticated``.
The ``auth`` module must accept users with empty passwords to make this work. That's a bit dangerous since anyone can login with a empty password unless the web server filters the **AUTHORIZATION** header.