### PR TITLE
HTTP error messages

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -54,8 +54,6 @@ NOT_ALLOWED = (client.FORBIDDEN, {"Content-type": "text/plain"},
                "Access to the requested resource forbidden.")
 NOT_FOUND = (client.NOT_FOUND, {"Content-type": "text/plain"},
              "The requested resource could not be found.")
-GONE = (client.GONE, {"Content-type": "text/plain"},
-        "The requested resource is no longer available.")
 WEBDAV_PRECONDITION_FAILED = (client.CONFLICT, {"Content-type": "text/plain"},
                               "WebDAV precondition failed.")
 PRECONDITION_FAILED = (client.PRECONDITION_FAILED,
@@ -425,7 +423,7 @@ class Application:
             if not self._access(user, path, "w", item):
                 return NOT_ALLOWED
             if not item:
-                return GONE
+                return NOT_FOUND
             if_match = environ.get("HTTP_IF_MATCH", "*")
             if if_match not in ("*", item.etag):
                 # ETag precondition not verified, do not delete item
@@ -519,7 +517,7 @@ class Application:
             if not self._access(user, to_path, "w", item):
                 return NOT_ALLOWED
             if not item:
-                return GONE
+                return NOT_FOUND
             if isinstance(item, self.Collection):
                 return WEBDAV_PRECONDITION_FAILED
 

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -67,6 +67,8 @@ REQUEST_ENTITY_TOO_LARGE = (client.REQUEST_ENTITY_TOO_LARGE,
                             "Request body too large.")
 REMOTE_DESTINATION = (client.BAD_GATEWAY, {"Content-type": "text/plain"},
                       "Remote destination not supported.")
+DIRECTORY_LISTING = (client.FORBIDDEN, {"Content-type": "text/plain"},
+                     "Directory listings are not supported.")
 
 DAV_HEADERS = "1, 2, 3, calendar-access, addressbook, extended-mkcol"
 
@@ -451,6 +453,8 @@ class Application:
                 return NOT_FOUND
             if isinstance(item, self.Collection):
                 collection = item
+                if collection.get_meta("tag") not in ("VADDRESSBOOK", "VCALENDAR"):
+                    return DIRECTORY_LISTING
             else:
                 collection = item.collection
             content_type = xmlutils.MIMETYPES.get(

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -736,8 +736,8 @@ class BaseRequestsMixIn:
     def test_principal_collection_creation(self):
         """Verify existence of the principal collection."""
         status, headers, answer = self.request(
-            "GET", "/user/", REMOTE_USER="user")
-        assert status == 200
+            "PROPFIND", "/user/", REMOTE_USER="user")
+        assert status == 207
 
     def test_existence_of_root_collections(self):
         """Verify that the root collection always exists."""
@@ -762,8 +762,8 @@ class BaseRequestsMixIn:
                                                          "created_by_hook"))
         status, headers, answer = self.request("MKCOL", "/calendar.ics/")
         assert status == 201
-        status, headers, answer = self.request("GET", "/created_by_hook/")
-        assert status == 200
+        status, headers, answer = self.request("PROPFIND", "/created_by_hook/")
+        assert status == 207
 
     def test_hook_read_access(self):
         """Verify that hook is not run for read accesses."""
@@ -791,8 +791,8 @@ class BaseRequestsMixIn:
                                                          "created_by_hook"))
         status, headers, answer = self.request("GET", "/", REMOTE_USER="user")
         assert status == 200
-        status, headers, answer = self.request("GET", "/created_by_hook/")
-        assert status == 200
+        status, headers, answer = self.request("PROPFIND", "/created_by_hook/")
+        assert status == 207
 
     def test_hook_fail(self):
         """Verify that a request fails if the hook fails."""


### PR DESCRIPTION
Browsers just show a blank page if an error occurs. You have to open the developer tools to see the HTTP status code. E.g. a user wants to download a calendar in the browser and the URL is wrong.
Some tools like curl don't show any indication of an error.

Some additional improvements concerning HTTP errors:

  * Return a error message instead of a blank page for GET requests on directories .(The same behaviour as most web servers.)
  * Don't use the GONE status code as Thunderbird doesn't recognize it correctly and shows synchronization errors.