### PR TITLE
Plain text for GET / instead of malformed HTML

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -421,9 +421,7 @@ class Application:
         """Manage GET request."""
         # Display a "Radicale works!" message if the root URL is requested
         if not path.strip("/"):
-            headers = {"Content-type": "text/html"}
-            answer = "<!DOCTYPE html>\n<title>Radicale</title>Radicale works!"
-            return client.OK, headers, answer
+            return client.OK, {"Content-type": "text/plain"}, "Radicale works!"
         if not self._access(user, path, "r"):
             return NOT_ALLOWED
         with self.Collection.acquire_lock("r", user):


### PR DESCRIPTION
It's basically the same in browsers and looks nicer in tools that don't support HTML rendering (like curl).