### PR TITLE
Improve formatting of log messages

### DIFF
--- a/logging
+++ b/logging
@@ -53,7 +53,7 @@ formatter = full
 
 [formatter_simple]
 # Simple output format
-format = %(message)s
+format = [%(thread)x] %(levelname)s: %(message)s
 
 [formatter_full]
 # Full output format

--- a/logging
+++ b/logging
@@ -57,4 +57,4 @@ format = %(message)s
 
 [formatter_full]
 # Full output format
-format = %(asctime)s - %(thread)d - %(levelname)s: %(message)s
+format = %(asctime)s - [%(thread)x] %(levelname)s: %(message)s

--- a/radicale/log.py
+++ b/radicale/log.py
@@ -56,7 +56,8 @@ def start(name="radicale", filename=None, debug=False):
                 "Logging configuration file '%s' not found, using stderr." %
                 filename)
         handler = logging.StreamHandler(sys.stderr)
-        handler.setFormatter(logging.Formatter("%(message)s"))
+        handler.setFormatter(
+            logging.Formatter("[%(thread)x] %(levelname)s: %(message)s"))
         logger.addHandler(handler)
     if debug:
         logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Adds thread and level in simple log formatter and to the default formatter. The console log is not very useful without this additional information, when requests overlap.

Slightly changes the format:
Old: ... - 139891659843328 - INFO: Starting Radicale
New: ... - [7f3b10b12700] INFO: Starting Radicale