### PR TITLE
Cleanup/Improve storage.py

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -142,7 +142,8 @@ def is_safe_path_component(path):
 
 
 def is_safe_filesystem_path_component(path):
-    """Check if path is a single component of a filesystem path.
+    """Check if path is a single component of a local and posix filesystem
+       path.
 
     Check that the path is safe to join too.
 
@@ -150,7 +151,8 @@ def is_safe_filesystem_path_component(path):
     return (
         path and not os.path.splitdrive(path)[0] and
         not os.path.split(path)[0] and path not in (os.curdir, os.pardir) and
-        not path.startswith(".") and not path.endswith("~"))
+        not path.startswith(".") and not path.endswith("~") and
+        is_safe_path_component(path))
 
 
 def path_to_filesystem(root, *paths):
@@ -628,7 +630,7 @@ class Collection(BaseCollection):
     def get(self, href):
         if not href:
             return None
-        href = href.strip("{}").replace("/", "_")
+        href = href.strip("{}")
         if not is_safe_filesystem_path_component(href):
             self.logger.debug(
                 "Can't translate name safely to filesystem: %s", href)

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -193,12 +193,6 @@ class ComponentNotFoundError(ValueError):
         super().__init__(message)
 
 
-class EtagMismatchError(ValueError):
-    def __init__(self, etag1, etag2):
-        message = "ETags don't match: %s != %s" % (etag1, etag2)
-        super().__init__(message)
-
-
 class Item:
     def __init__(self, collection, item, href, last_modified=None):
         self.collection = collection

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -125,7 +125,7 @@ def sanitize_path(path):
     path = posixpath.normpath(path)
     new_path = "/"
     for part in path.split("/"):
-        if not part or part in (".", ".."):
+        if not is_safe_path_component(part):
             continue
         new_path = posixpath.join(new_path, part)
     trailing_slash = "" if new_path.endswith("/") else trailing_slash

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -618,7 +618,6 @@ class Collection(BaseCollection):
     def get(self, href):
         if not href:
             return None
-        href = href.strip("{}")
         if not is_safe_filesystem_path_component(href):
             self.logger.debug(
                 "Can't translate name safely to filesystem: %s", href)

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -584,6 +584,8 @@ class Collection(BaseCollection):
         """
         fs = []
         for href, item in vobject_items.items():
+            if not is_safe_filesystem_path_component(href):
+                raise UnsafePathError(href)
             path = path_to_filesystem(self._filesystem_path, href)
             fs.append(open(path, "w", encoding=self.encoding, newline=""))
             fs[-1].write(item.serialize())
@@ -595,6 +597,8 @@ class Collection(BaseCollection):
 
     @classmethod
     def move(cls, item, to_collection, to_href):
+        if not is_safe_filesystem_path_component(to_href):
+            raise UnsafePathError(to_href)
         os.replace(
             path_to_filesystem(item.collection._filesystem_path, item.href),
             path_to_filesystem(to_collection._filesystem_path, to_href))

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -633,9 +633,6 @@ class Collection(BaseCollection):
             time.gmtime(os.path.getmtime(path)))
         return Item(self, vobject.readOne(text), href, last_modified)
 
-    def has(self, href):
-        return self.get(href) is not None
-
     def upload(self, href, vobject_item):
         if not is_safe_filesystem_path_component(href):
             raise UnsafePathError(href)

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -686,9 +686,12 @@ class Collection(BaseCollection):
 
     @property
     def last_modified(self):
-        last = max([os.path.getmtime(self._filesystem_path)] + [
-            os.path.getmtime(os.path.join(self._filesystem_path, filename))
-            for filename in os.listdir(self._filesystem_path)] or [0])
+        relevant_files = [self._filesystem_path] + [
+            path_to_filesystem(self._filesystem_path, href)
+            for href in self.list()]
+        if os.path.exists(self._props_path):
+            relevant_files.append(self._props_path)
+        last = max(map(os.path.getmtime, relevant_files))
         return time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(last))
 
     def serialize(self):

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -698,17 +698,9 @@ class Collection(BaseCollection):
         return time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(last))
 
     def serialize(self):
-        if not os.path.exists(self._filesystem_path):
-            return None
         items = []
-        for href in os.listdir(self._filesystem_path):
-            if not is_safe_filesystem_path_component(href):
-                self.logger.debug("Skipping component: %s", href)
-                continue
-            path = os.path.join(self._filesystem_path, href)
-            if os.path.isfile(path):
-                with open(path, encoding=self.encoding, newline="") as fd:
-                    items.append(vobject.readOne(fd.read()))
+        for href in self.list():
+            items.append(self.get(href).item)
         if self.get_meta("tag") == "VCALENDAR":
             collection = vobject.iCalendar()
             for item in items:

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -100,7 +100,11 @@ def load(configuration, logger):
 
 
 def get_etag(text):
-    """Etag from collection or item."""
+    """Etag from collection or item.
+
+    Encoded as quoted-string (see RFC 2616).
+
+    """
     etag = md5()
     etag.update(text.encode("utf-8"))
     return '"%s"' % etag.hexdigest()
@@ -205,6 +209,7 @@ class Item:
 
     @property
     def etag(self):
+        """Encoded as quoted-string (see RFC 2616)."""
         return get_etag(self.serialize())
 
 
@@ -262,6 +267,7 @@ class BaseCollection:
 
     @property
     def etag(self):
+        """Encoded as quoted-string (see RFC 2616)."""
         return get_etag(self.serialize())
 
     @classmethod

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -607,12 +607,7 @@ class Collection(BaseCollection):
             cls._sync_directory(item.collection._filesystem_path)
 
     def list(self):
-        try:
-            hrefs = os.listdir(self._filesystem_path)
-        except IOError:
-            return
-
-        for href in hrefs:
+        for href in os.listdir(self._filesystem_path):
             if not is_safe_filesystem_path_component(href):
                 self.logger.debug("Skipping component: %s", href)
                 continue
@@ -653,18 +648,17 @@ class Collection(BaseCollection):
     def delete(self, href=None):
         if href is None:
             # Delete the collection
-            if os.path.isdir(self._filesystem_path):
-                parent_dir = os.path.dirname(self._filesystem_path)
-                try:
-                    os.rmdir(self._filesystem_path)
-                except OSError:
-                    with TemporaryDirectory(
-                            prefix=".Radicale.tmp-", dir=parent_dir) as tmp:
-                        os.rename(self._filesystem_path, os.path.join(
-                            tmp, os.path.basename(self._filesystem_path)))
-                        self._sync_directory(parent_dir)
-                else:
+            parent_dir = os.path.dirname(self._filesystem_path)
+            try:
+                os.rmdir(self._filesystem_path)
+            except OSError:
+                with TemporaryDirectory(
+                        prefix=".Radicale.tmp-", dir=parent_dir) as tmp:
+                    os.rename(self._filesystem_path, os.path.join(
+                        tmp, os.path.basename(self._filesystem_path)))
                     self._sync_directory(parent_dir)
+            else:
+                self._sync_directory(parent_dir)
         else:
             # Delete an item
             if not is_safe_filesystem_path_component(href):

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -631,7 +631,12 @@ class Collection(BaseCollection):
         last_modified = time.strftime(
             "%a, %d %b %Y %H:%M:%S GMT",
             time.gmtime(os.path.getmtime(path)))
-        return Item(self, vobject.readOne(text), href, last_modified)
+        try:
+            item = vobject.readOne(text)
+        except Exception:
+            self.logger.error("Failed to parse component: %s", href)
+            raise
+        return Item(self, item, href, last_modified)
 
     def upload(self, href, vobject_item):
         if not is_safe_filesystem_path_component(href):

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -626,8 +626,8 @@ class Collection(BaseCollection):
         path = path_to_filesystem(self._filesystem_path, href)
         if not os.path.isfile(path):
             return None
-        with open(path, encoding=self.encoding, newline="") as fd:
-            text = fd.read()
+        with open(path, encoding=self.encoding, newline="") as f:
+            text = f.read()
         last_modified = time.strftime(
             "%a, %d %b %Y %H:%M:%S GMT",
             time.gmtime(os.path.getmtime(path)))
@@ -671,18 +671,18 @@ class Collection(BaseCollection):
 
     def get_meta(self, key):
         if os.path.exists(self._props_path):
-            with open(self._props_path, encoding=self.encoding) as prop:
-                return json.load(prop).get(key)
+            with open(self._props_path, encoding=self.encoding) as f:
+                return json.load(f).get(key)
 
     def set_meta(self, props):
         if os.path.exists(self._props_path):
-            with open(self._props_path, encoding=self.encoding) as prop:
-                old_props = json.load(prop)
+            with open(self._props_path, encoding=self.encoding) as f:
+                old_props = json.load(f)
                 old_props.update(props)
                 props = old_props
         props = {key: value for key, value in props.items() if value}
-        with self._atomic_write(self._props_path, "w+") as prop:
-            json.dump(props, prop)
+        with self._atomic_write(self._props_path, "w+") as f:
+            json.dump(props, f)
 
     @property
     def last_modified(self):


### PR DESCRIPTION
 a12ef69 and  5dbf9df add missing checks for safe conversion of paths to the local filesystem. They are only relevant on Windows and currently it's not possible to exploit it.

 6df54bf adds a log message that includes the name of a faulty component. Before only the exception from vobject showed up in the log but the filename of the component that caused the error was missing.

The Collection.get method stripped {} from `href`, 03fbb1e removes that. If someone uploaded a component that starts or ends with { or }, all REPORT requests on that collection failed and it was impossible to delete the component.
@liZe Why was that there in the first place? I couldn't find something like this in the relevant RFCs and hope removing it doesn't break some client.

de09f66 changes last_modified to only look at relevant files.

All other changes are just cosmetic.
