### PR TITLE
Remove base_prefix

### DIFF
--- a/config
+++ b/config
@@ -51,12 +51,6 @@
 # Reverse DNS to resolve client address in logs
 #dns_lookup = True
 
-# Root URL of Radicale (starting and ending with a slash)
-#base_prefix = /
-
-# Possibility to allow URLs cleaned by a HTTP server, without the base_prefix
-#can_skip_base_prefix = False
-
 # Message displayed in the client when a password is needed
 #realm = Radicale - Password Required
 

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -307,19 +307,11 @@ class Application:
         headers = pprint.pformat(self.headers_log(environ))
         self.logger.debug("Request headers:\n%s", headers)
 
-        # Strip base_prefix from request URI
-        base_prefix = self.configuration.get("server", "base_prefix")
-        if environ["PATH_INFO"].startswith(base_prefix):
-            environ["PATH_INFO"] = environ["PATH_INFO"][len(base_prefix):]
-        elif self.configuration.get("server", "can_skip_base_prefix"):
-            self.logger.debug(
-                "Prefix already stripped from path: %s", environ["PATH_INFO"])
-        else:
-            # Request path not starting with base_prefix, not allowed
-            self.logger.debug(
-                "Path not starting with prefix: %s", environ["PATH_INFO"])
-            return response(*NOT_ALLOWED)
-
+        # Sanitize base prefix
+        environ["SCRIPT_NAME"] = storage.sanitize_path(
+            environ.get("SCRIPT_NAME", "")).rstrip("/")
+        self.logger.debug("Sanitized script name: %s", environ["SCRIPT_NAME"])
+        base_prefix = environ["SCRIPT_NAME"]
         # Sanitize request URI
         environ["PATH_INFO"] = storage.sanitize_path(
             unquote(environ["PATH_INFO"]))
@@ -376,7 +368,8 @@ class Application:
 
         if is_valid_user:
             try:
-                status, headers, answer = function(environ, path, user)
+                status, headers, answer = function(
+                    environ, base_prefix, path, user)
             except socket.timeout:
                 return response(*REQUEST_TIMEOUT)
         else:
@@ -423,7 +416,7 @@ class Application:
             content = None
         return content
 
-    def do_DELETE(self, environ, path, user):
+    def do_DELETE(self, environ, base_prefix, path, user):
         """Manage DELETE request."""
         if not self._access(user, path, "w"):
             return NOT_ALLOWED
@@ -438,12 +431,13 @@ class Application:
                 # ETag precondition not verified, do not delete item
                 return PRECONDITION_FAILED
             if isinstance(item, self.Collection):
-                answer = xmlutils.delete(path, item)
+                answer = xmlutils.delete(base_prefix, path, item)
             else:
-                answer = xmlutils.delete(path, item.collection, item.href)
+                answer = xmlutils.delete(
+                    base_prefix, path, item.collection, item.href)
             return client.OK, {}, answer
 
-    def do_GET(self, environ, path, user):
+    def do_GET(self, environ, base_prefix, path, user):
         """Manage GET request."""
         # Display a "Radicale works!" message if the root URL is requested
         if not path.strip("/"):
@@ -471,12 +465,13 @@ class Application:
             answer = item.serialize()
             return client.OK, headers, answer
 
-    def do_HEAD(self, environ, path, user):
+    def do_HEAD(self, environ, base_prefix, path, user):
         """Manage HEAD request."""
-        status, headers, answer = self.do_GET(environ, path, user)
+        status, headers, answer = self.do_GET(
+            environ, base_prefix, path, user)
         return status, headers, None
 
-    def do_MKCALENDAR(self, environ, path, user):
+    def do_MKCALENDAR(self, environ, base_prefix, path, user):
         """Manage MKCALENDAR request."""
         if not self.authorized(user, path, "w"):
             return NOT_ALLOWED
@@ -492,7 +487,7 @@ class Application:
             self.Collection.create_collection(path, props=props)
             return client.CREATED, {}, None
 
-    def do_MKCOL(self, environ, path, user):
+    def do_MKCOL(self, environ, base_prefix, path, user):
         """Manage MKCOL request."""
         if not self.authorized(user, path, "w"):
             return NOT_ALLOWED
@@ -505,7 +500,7 @@ class Application:
             self.Collection.create_collection(path, props=props)
             return client.CREATED, {}, None
 
-    def do_MOVE(self, environ, path, user):
+    def do_MOVE(self, environ, base_prefix, path, user):
         """Manage MOVE request."""
         to_url = urlparse(environ["HTTP_DESTINATION"])
         if to_url.netloc != environ["HTTP_HOST"]:
@@ -542,7 +537,7 @@ class Application:
             self.Collection.move(item, to_collection, to_href)
             return client.CREATED, {}, None
 
-    def do_OPTIONS(self, environ, path, user):
+    def do_OPTIONS(self, environ, base_prefix, path, user):
         """Manage OPTIONS request."""
         headers = {
             "Allow": ", ".join(
@@ -550,7 +545,7 @@ class Application:
             "DAV": DAV_HEADERS}
         return client.OK, headers, None
 
-    def do_PROPFIND(self, environ, path, user):
+    def do_PROPFIND(self, environ, base_prefix, path, user):
         """Manage PROPFIND request."""
         if not self._access(user, path, "r"):
             return NOT_ALLOWED
@@ -569,13 +564,13 @@ class Application:
             read_items, write_items = self.collect_allowed_items(items, user)
             headers = {"DAV": DAV_HEADERS, "Content-Type": "text/xml"}
             status, answer = xmlutils.propfind(
-                path, content, read_items, write_items, user)
+                base_prefix, path, content, read_items, write_items, user)
             if status == client.FORBIDDEN:
                 return NOT_ALLOWED
             else:
                 return status, headers, answer
 
-    def do_PROPPATCH(self, environ, path, user):
+    def do_PROPPATCH(self, environ, base_prefix, path, user):
         """Manage PROPPATCH request."""
         if not self.authorized(user, path, "w"):
             return NOT_ALLOWED
@@ -585,10 +580,10 @@ class Application:
             if not isinstance(item, self.Collection):
                 return WEBDAV_PRECONDITION_FAILED
             headers = {"DAV": DAV_HEADERS, "Content-Type": "text/xml"}
-            answer = xmlutils.proppatch(path, content, item)
+            answer = xmlutils.proppatch(base_prefix, path, content, item)
             return client.MULTI_STATUS, headers, answer
 
-    def do_PUT(self, environ, path, user):
+    def do_PUT(self, environ, base_prefix, path, user):
         """Manage PUT request."""
         if not self._access(user, path, "w"):
             return NOT_ALLOWED
@@ -640,7 +635,7 @@ class Application:
             headers = {"ETag": new_item.etag}
             return client.CREATED, headers, None
 
-    def do_REPORT(self, environ, path, user):
+    def do_REPORT(self, environ, base_prefix, path, user):
         """Manage REPORT request."""
         if not self._access(user, path, "w"):
             return NOT_ALLOWED
@@ -656,5 +651,5 @@ class Application:
             else:
                 collection = item.collection
             headers = {"Content-Type": "text/xml"}
-            answer = xmlutils.report(path, content, collection)
+            answer = xmlutils.report(base_prefix, path, content, collection)
             return client.MULTI_STATUS, headers, answer

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -171,7 +171,7 @@ class RequestHandler(wsgiref.simple_server.WSGIRequestHandler):
     def get_environ(self):
         env = super().get_environ()
         # Parent class only tries latin1 encoding
-        env["PATH_INFO"] = urllib.parse.unquote(self.path.split("?", 1)[0])
+        env["PATH_INFO"] = unquote(self.path.split("?", 1)[0])
         return env
 
     def handle(self):

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -307,6 +307,11 @@ class Application:
         headers = pprint.pformat(self.headers_log(environ))
         self.logger.debug("Request headers:\n%s", headers)
 
+        # Let reverse proxies overwrite SCRIPT_NAME
+        if "HTTP_X_SCRIPT_NAME" in environ:
+            environ["SCRIPT_NAME"] = environ["HTTP_X_SCRIPT_NAME"]
+            self.logger.debug("Script name overwritten by client: %s",
+                              environ["SCRIPT_NAME"])
         # Sanitize base prefix
         environ["SCRIPT_NAME"] = storage.sanitize_path(
             environ.get("SCRIPT_NAME", "")).rstrip("/")

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -313,8 +313,7 @@ class Application:
         self.logger.debug("Sanitized script name: %s", environ["SCRIPT_NAME"])
         base_prefix = environ["SCRIPT_NAME"]
         # Sanitize request URI
-        environ["PATH_INFO"] = storage.sanitize_path(
-            unquote(environ["PATH_INFO"]))
+        environ["PATH_INFO"] = storage.sanitize_path(environ["PATH_INFO"])
         self.logger.debug("Sanitized path: %s", environ["PATH_INFO"])
         path = environ["PATH_INFO"]
 

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -153,9 +153,6 @@ def serve(configuration, logger):
     atexit.register(cleanup)
     logger.info("Starting Radicale")
 
-    logger.debug(
-        "Base URL prefix: %s", configuration.get("server", "base_prefix"))
-
     # Create collection servers
     servers = {}
     if configuration.getboolean("server", "ssl"):

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -41,8 +41,6 @@ INITIAL_CONFIG = {
         "protocol": "PROTOCOL_SSLv23",
         "ciphers": "",
         "dns_lookup": "True",
-        "base_prefix": "/",
-        "can_skip_base_prefix": "False",
         "realm": "Radicale - Password Required"},
     "encoding": {
         "request": "utf-8",

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -853,7 +853,7 @@ def _item_response(base_prefix, href, found_props=(), not_found_props=(),
     response = ET.Element(_tag("D", "response"))
 
     href_tag = ET.Element(_tag("D", "href"))
-    href_tag.text = href
+    href_tag.text = _href(base_prefix, href)
     response.append(href_tag)
 
     if found_item:

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -31,7 +31,7 @@ import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from http import client
-from urllib.parse import unquote, urlparse
+from urllib.parse import quote, unquote, urlparse
 
 from . import storage
 
@@ -104,7 +104,7 @@ def _response(code):
 
 def _href(base_prefix, href):
     """Return prefixed href."""
-    return "%s%s" % (base_prefix, href)
+    return quote("%s%s" % (base_prefix, href))
 
 
 def _date_to_datetime(date_):

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -423,7 +423,11 @@ def name_from_path(path, collection):
     start = collection.path + "/"
     if not path.startswith(start):
         raise ValueError("'%s' doesn't start with '%s'" % (path, start))
-    return path[len(start):].rstrip("/")
+    name = path[len(start):][:-1]
+    if name and not storage.is_safe_path_component(name):
+        raise ValueError("'%s' is not a component in collection '%s'" %
+                         (path, collection.path))
+    return name
 
 
 def props_from_request(root, actions=("set", "remove")):

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -766,7 +766,8 @@ def report(base_prefix, path, xml_request, collection):
             # Read rfc4791-7.9 for info
             hreferences = set()
             for href_element in root.findall(_tag("D", "href")):
-                href_path = unquote(urlparse(href_element.text).path)
+                href_path = storage.sanitize_path(
+                    unquote(urlparse(href_element.text).path))
                 if (href_path + "/").startswith(base_prefix + "/"):
                     hreferences.add(href_path[len(base_prefix):])
         else:


### PR DESCRIPTION
This removes the `base_prefix` and `can_skip_base_prefix` configuration options. Instead the `SCRIPT_NAME` environment variable is used according to PEP 333.

For reverse proxies the HTTP header `X-Script-Name` is introduced which allows overwriting of the `SCRIPT_NAME` variable ([Source](http://flask.pocoo.org/snippets/35/)). This solution is cleaner and also allows multiple reverse proxies simultaneously.

Example Nginx configuration:

```
location /sub/folder/radicale {
    proxy_pass localhost:5232/; # The / is important!
    proxy_set_header X-Script-Name /sub/folder/radicale;
}
```

This fixes some additional smaller issues with URL handling:
- The request URL was double unquoted: `%2525` evaluated to `%` instead of `%25`.
- URLs from XML requests were not sanitized
- Invalid URLs in XML requests were just silently ignored. This PR adds some log messages.
- `name_from_path` function didn't check that the name is valid. For example it could return something like `user/calendar.ics`.
- hreferences in REPORT responses were not expanded with `base_prefix`
- hreferences in XML responses were not quoted. [RFC 4918](https://tools.ietf.org/html/rfc4918) states that they are URIs and [RFC 3986](https://tools.ietf.org/html/rfc3986) says that URIs must always be in percent-encoded form.
