### PR TITLE
try/catch of objects avoiding not serving any object in case an object has no valid contents

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -244,6 +244,8 @@ class Application:
         read_allowed_items = []
         write_allowed_items = []
         for item in items:
+            if not item:
+                continue
             if isinstance(item, self.Collection):
                 path = item.path
             else:

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -635,7 +635,12 @@ class Collection(BaseCollection):
         last_modified = time.strftime(
             "%a, %d %b %Y %H:%M:%S GMT",
             time.gmtime(os.path.getmtime(path)))
-        return Item(self, vobject.readOne(text), href, last_modified)
+        try:
+            item = Item(self, vobject.readOne(text), href, last_modified)
+        except:
+            self.logger.error("Object broken (skip 'get'): %s", path)
+            return None;
+        return item;
 
     def has(self, href):
         return self.get(href) is not None
@@ -712,7 +717,7 @@ class Collection(BaseCollection):
                     try:
                         items.append(vobject.readOne(fd.read()))
                     except:
-                        self.logger.error("Object broken (skip): %s", path)
+                        self.logger.error("Object broken (skip 'list'): %s", path)
         time_end = datetime.datetime.now()
         self.logger.info("Collection read %d items in %s sec from %s", len(items),(time_end - time_begin).total_seconds(), self._filesystem_path)
         if self.get_meta("tag") == "VCALENDAR":

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -638,7 +638,7 @@ class Collection(BaseCollection):
         try:
             item = Item(self, vobject.readOne(text), href, last_modified)
         except:
-            self.logger.error("Object broken (skip 'get'): %s", path)
+            self.logger.exception("Object broken (skip 'get'): %s", path)
             return None;
         return item;
 
@@ -717,7 +717,7 @@ class Collection(BaseCollection):
                     try:
                         items.append(vobject.readOne(fd.read()))
                     except:
-                        self.logger.error("Object broken (skip 'list'): %s", path)
+                        self.logger.exception("Object broken (skip 'list'): %s", path)
         time_end = datetime.datetime.now()
         self.logger.info("Collection read %d items in %s sec from %s", len(items),(time_end - time_begin).total_seconds(), self._filesystem_path)
         if self.get_meta("tag") == "VCALENDAR":

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -796,6 +796,8 @@ def report(path, xml_request, collection):
             items = collection.pre_filtered_list(filters)
 
         for item in items:
+            if not item:
+                continue
             if filters:
                 match = (
                     _comp_match if collection.get_meta("tag") == "VCALENDAR"


### PR DESCRIPTION
detected the need of try/catch while having a broken ICS file

also log duration of how many objects are read per folder for statistical/diagnostic purposes
