### PR TITLE
remove umask(0) in daemon mode

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -132,7 +132,6 @@ def serve(configuration, logger):
             with os.fdopen(pid_fd, "w") as pid_file:
                 pid_file.write(str(os.getpid()))
         # Decouple environment
-        os.umask(0)
         os.chdir("/")
         os.setsid()
         with open(os.devnull, "r") as null_in:


### PR DESCRIPTION
Can we please remove the umask(0) in daemon mode?

I don't like having files left with world write access. World read is unnecessary for this daemon as well.

Without a configuration option that allows an administrator to specify the umask, I think simply removing this umask makes sense.

Resetting the umask to zero might make sense in other cases. In this case, it is not necessary. In fact, it stops an administrator from properly implementing permissions.