### PR TITLE
Change default values for the config

### DIFF
--- a/config
+++ b/config
@@ -15,8 +15,7 @@
 # IPv4 syntax: address:port
 # IPv6 syntax: [address]:port
 # For example: 0.0.0.0:9999, [::]:9999
-# IPv6 adresses are configured to only allow IPv6 connections
-#hosts = 0.0.0.0:5232
+#hosts = 127.0.0.1:5232
 
 # Daemon flag
 #daemon = False
@@ -37,13 +36,13 @@
 #ssl = False
 
 # SSL certificate path
-#certificate = /etc/apache2/ssl/server.crt
+#certificate = /etc/ssl/radicale.cert.pem
 
 # SSL private key
-#key = /etc/apache2/ssl/server.key
+#key = /etc/ssl/radicale.key.pem
 
 # SSL Protocol used. See python's ssl module for available values
-#protocol = PROTOCOL_SSLv23
+#protocol = PROTOCOL_TLSv1_2
 
 # Available ciphers. See python's ssl module for available ciphers
 #ciphers =
@@ -75,17 +74,19 @@
 
 # Htpasswd encryption method
 # Value: plain | sha1 | ssha | crypt | bcrypt | md5
-#htpasswd_encryption = crypt
+# Only bcrypt can be considered secure.
+# bcrypt and md5 require the passlib library to be installed.
+#htpasswd_encryption = bcrypt
 
 
 [rights]
 
 # Rights backend
 # Value: None | authenticated | owner_only | owner_write | from_file
-#type = None
+#type = owner_only
 
 # File for rights management from_file
-#file = ~/.config/radicale/rights
+#file = /etc/radicale/rights
 
 
 [storage]
@@ -95,7 +96,7 @@
 #type = filesystem
 
 # Folder for storing local collections, created if not present
-#filesystem_folder = ~/.config/radicale/collections
+#filesystem_folder = /etc/radicale/collections
 
 # Sync all changes to disk during requests. (This can impair performance.)
 # Disabling it increases the risk of data loss, when the system crashes or

--- a/config
+++ b/config
@@ -93,10 +93,10 @@
 
 # Storage backend
 # Value: multifilesystem
-#type = filesystem
+#type = multifilesystem
 
 # Folder for storing local collections, created if not present
-#filesystem_folder = /etc/radicale/collections
+#filesystem_folder = /var/lib/radicale/collections
 
 # Sync all changes to disk during requests. (This can impair performance.)
 # Disabling it increases the risk of data loss, when the system crashes or

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -31,7 +31,7 @@ from configparser import RawConfigParser as ConfigParser
 INITIAL_CONFIG = OrderedDict([
     ("server", OrderedDict([
         ("hosts", {
-            "value": "0.0.0.0:5232",
+            "value": "127.0.0.1:5232",
             "help": "set server hostnames including ports",
             "aliases": ["-H", "--hosts"]}),
         ("daemon", {
@@ -58,15 +58,15 @@ INITIAL_CONFIG = OrderedDict([
             "aliases": ["-s", "--ssl"],
             "opposite": ["-S", "--no-ssl"]}),
         ("certificate", {
-            "value": "/etc/apache2/ssl/server.crt",
+            "value": "/etc/ssl/radicale.cert.pem",
             "help": "set certificate file",
             "aliases": ["-c", "--certificate"]}),
         ("key", {
-            "value": "/etc/apache2/ssl/server.key",
+            "value": "/etc/ssl/radicale.key.pem",
             "help": "set private key file",
             "aliases": ["-k", "--key"]}),
         ("protocol", {
-            "value": "PROTOCOL_SSLv23",
+            "value": "PROTOCOL_TLSv1_2",
             "help": "SSL protocol used"}),
         ("ciphers", {
             "value": "",
@@ -92,14 +92,14 @@ INITIAL_CONFIG = OrderedDict([
             "value": "/etc/radicale/users",
             "help": "htpasswd filename"}),
         ("htpasswd_encryption", {
-            "value": "crypt",
+            "value": "bcrypt",
             "help": "htpasswd encryption method"})])),
     ("rights", OrderedDict([
         ("type", {
-            "value": "None",
+            "value": "owner_only",
             "help": "rights backend"}),
         ("file", {
-            "value": "~/.config/radicale/rights",
+            "value": "/etc/radicale/rights",
             "help": "file for rights management from_file"})])),
     ("storage", OrderedDict([
         ("type", {
@@ -107,7 +107,7 @@ INITIAL_CONFIG = OrderedDict([
             "help": "storage backend"}),
         ("filesystem_folder", {
             "value": os.path.expanduser(
-                "~/.config/radicale/collections"),
+                "/etc/radicale/collections"),
             "help": "file for rights management from_file"}),
         ("filesystem_fsync", {
             "value": "True",

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -107,7 +107,7 @@ INITIAL_CONFIG = OrderedDict([
             "help": "storage backend"}),
         ("filesystem_folder", {
             "value": os.path.expanduser(
-                "/etc/radicale/collections"),
+                "/var/lib/radicale/collections"),
             "help": "file for rights management from_file"}),
         ("filesystem_fsync", {
             "value": "True",

--- a/radicale/rights.py
+++ b/radicale/rights.py
@@ -48,8 +48,9 @@ from . import storage
 
 def load(configuration, logger):
     """Load the rights manager chosen in configuration."""
+    auth_type = configuration.get("auth", "type")
     rights_type = configuration.get("rights", "type")
-    if rights_type == "None":
+    if auth_type == "None" or rights_type == "None":
         return lambda user, collection, permission: True
     elif rights_type in DEFINED_RIGHTS or rights_type == "from_file":
         return Rights(configuration, logger).authorized

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -768,6 +768,8 @@ class BaseRequestsMixIn:
 
     def test_authentication(self):
         """Test if server sends authentication request."""
+        self.configuration.set("auth", "type", "htpasswd")
+        self.configuration.set("auth", "htpasswd_filename", os.devnull)
         self.configuration.set("rights", "type", "owner_only")
         self.application = Application(self.configuration, self.logger)
         status, headers, answer = self.request("MKCOL", "/user/")

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -770,6 +770,7 @@ class BaseRequestsMixIn:
         """Test if server sends authentication request."""
         self.configuration.set("auth", "type", "htpasswd")
         self.configuration.set("auth", "htpasswd_filename", os.devnull)
+        self.configuration.set("auth", "htpasswd_encryption", "plain")
         self.configuration.set("rights", "type", "owner_only")
         self.application = Application(self.configuration, self.logger)
         status, headers, answer = self.request("MKCOL", "/user/")


### PR DESCRIPTION
This issue is open as a discussion to fix #346.

As proposed by @szotsaki, default values should be more secure, but we also must try to keep a default configuration that works out-of-the-box for new users.