### PR TITLE
Use logger for WSGIServer

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -36,7 +36,9 @@ import pprint
 import socket
 import socketserver
 import ssl
+import sys
 import threading
+import traceback
 import wsgiref.simple_server
 import zlib
 import datetime
@@ -84,6 +86,7 @@ class HTTPServer(wsgiref.simple_server.WSGIServer):
     # These class attributes must be set before creating instance
     client_timeout = None
     max_connections = None
+    logger = None
 
     def __init__(self, address, handler, bind_and_activate=True):
         """Create server."""
@@ -116,6 +119,13 @@ class HTTPServer(wsgiref.simple_server.WSGIServer):
         if self.client_timeout:
             _socket.settimeout(self.client_timeout)
         return _socket, address
+
+    def handle_error(self, request, client_address):
+        if issubclass(sys.exc_info()[0], socket.timeout):
+            self.logger.error("connection timeout")
+        else:
+            self.logger.error(
+                "An exception occurred during request:\n%s", traceback.format_exc())
 
 
 class HTTPSServer(HTTPServer):

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -173,6 +173,7 @@ def serve(configuration, logger):
     server_class.client_timeout = configuration.getint("server", "timeout")
     server_class.max_connections = configuration.getint(
         "server", "max_connections")
+    server_class.logger = logger
 
     RequestHandler.logger = logger
     if not configuration.getboolean("server", "dns_lookup"):


### PR DESCRIPTION
Log exception from the WSGIServer. Exceptions from socket timeouts are currently written to stderr.