### PR TITLE
Make Radicale fast

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -329,14 +329,17 @@ class BaseCollection:
         raise NotImplementedError
 
     def get_multi(self, hrefs):
-        """Fetch multiple items. Duplicate hrefs must be ignored.
+        """Fetch multiple items.
 
         Functionally similar to ``get``, but might bring performance benefits
-        on some storages when used cleverly.
+        on some storages when used cleverly. It's not required to return the
+        requested items in the correct order. Duplicated hrefs can be ignored.
+
+        Returns tuples with the href and the item or None if the item doesn't
+        exist.
 
         """
-        for href in set(hrefs):
-            yield self.get(href)
+        return map(lambda href: (href, self.get(href)), hrefs)
 
     def pre_filtered_list(self, filters):
         """List collection items with optional pre filtering.

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -858,8 +858,6 @@ class Collection(BaseCollection):
                 yield href
 
     def get(self, href):
-        if not href:
-            return None
         if not is_safe_filesystem_path_component(href):
             self.logger.debug("Can't translate name %r safely to filesystem "
                               "in %r", href, self.path)

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -1124,24 +1124,29 @@ class Collection(BaseCollection):
                 for line in item.serialize().split("\r\n"):
                     if line.startswith("BEGIN:"):
                         depth += 1
-                    if depth == 2 and line == "BEGIN:VTIMEZONE":
-                        vtimezone.append(line)
-                    elif vtimezone:
-                        vtimezone.append(line)
-                        if depth == 2 and line.startswith("TZID:"):
-                            tzid = line[len("TZID:"):]
-                        elif depth == 2 and line.startswith("END:"):
-                            if tzid is None or tzid not in included_tzids:
-                                if vtimezones:
-                                    vtimezones += "\r\n"
-                                vtimezones += "\r\n".join(vtimezone)
-                                included_tzids.add(tzid)
-                            vtimezone.clear()
-                            tzid = None
-                    elif depth >= 2:
-                        if components:
-                            components += "\r\n"
-                        components += line
+                    if depth == 1 and line == "BEGIN:VCALENDAR":
+                        in_vcalendar = True
+                    elif in_vcalendar:
+                        if depth == 1 and line.startswith("END:"):
+                            in_vcalendar = False
+                        if depth == 2 and line == "BEGIN:VTIMEZONE":
+                            vtimezone.append(line)
+                        elif vtimezone:
+                            vtimezone.append(line)
+                            if depth == 2 and line.startswith("TZID:"):
+                                tzid = line[len("TZID:"):]
+                            elif depth == 2 and line.startswith("END:"):
+                                if tzid is None or tzid not in included_tzids:
+                                    if vtimezones:
+                                        vtimezones += "\r\n"
+                                    vtimezones += "\r\n".join(vtimezone)
+                                    included_tzids.add(tzid)
+                                vtimezone.clear()
+                                tzid = None
+                        elif depth >= 2:
+                            if components:
+                                components += "\r\n"
+                            components += line
                     if line.startswith("END:"):
                         depth -= 1
             return "\r\n".join(filter(bool, (

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -940,11 +940,10 @@ class Collection(BaseCollection):
 
     @property
     def last_modified(self):
-        relevant_files = [self._filesystem_path] + [
-            path_to_filesystem(self._filesystem_path, href)
-            for href in self.list()]
-        if os.path.exists(self._props_path):
-            relevant_files.append(self._props_path)
+        relevant_files = chain(
+            (self._filesystem_path,),
+            (self._props_path,) if os.path.exists(self._props_path) else (),
+            map(lambda x: os.path.join(self._filesystem_path, x), self.list()))
         last = max(map(os.path.getmtime, relevant_files))
         return time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(last))
 

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -1034,16 +1034,16 @@ class Collection(BaseCollection):
         return map(lambda x: self.get(x, verify_href=False), self.list())
 
     def pre_filtered_list(self, filters):
-        tag, start, end = xmlutils.simplify_prefilters(filters)
+        tag, start, end, simple = xmlutils.simplify_prefilters(filters)
         if not tag:
             # no filter
-            yield from map(lambda item: (item, False), self.get_all())
+            yield from map(lambda item: (item, simple), self.get_all())
             return
         for item, (itag, istart, iend) in map(
                 lambda x: self._get_with_metadata(x, verify_href=False),
                 self.list()):
             if tag == itag and istart < end and iend > start:
-                yield item, False
+                yield item, simple and (start <= istart or iend <= end)
 
     def upload(self, href, vobject_item):
         if not is_safe_filesystem_path_component(href):

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -449,6 +449,7 @@ class Collection(BaseCollection):
         self.owner = split_path[0] if len(split_path) > 1 else None
         self.is_principal = principal
         self._meta = None
+        self._etag = None
 
     @classmethod
     def _get_collection_root_folder(cls):
@@ -1019,6 +1020,13 @@ class Collection(BaseCollection):
         elif self.get_meta("tag") == "VADDRESSBOOK":
             return "".join([item.serialize() for item in items])
         return ""
+
+    @property
+    def etag(self):
+        # reuse cached value if the storage is read-only
+        if self._writer or self._etag is None:
+            self._etag = super().etag
+        return self._etag
 
     _lock = threading.Lock()
     _waiters = []

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -870,10 +870,11 @@ class Collection(BaseCollection):
                 return None
         else:
             path = os.path.join(self._filesystem_path, href)
-        if not os.path.isfile(path):
+        try:
+            with open(path, encoding=self.encoding, newline="") as f:
+                text = f.read()
+        except (FileNotFoundError, IsADirectoryError):
             return None
-        with open(path, encoding=self.encoding, newline="") as f:
-            text = f.read()
         last_modified = time.strftime(
             "%a, %d %b %Y %H:%M:%S GMT",
             time.gmtime(os.path.getmtime(path)))

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -1111,42 +1111,20 @@ class Collection(BaseCollection):
         return time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(last))
 
     def serialize(self):
-        cache_folder = os.path.join(self._filesystem_path, ".Radicale.cache",
-                                    "serialization")
-        cache_name = self.etag.strip('"')
-        cache_path = os.path.join(cache_folder, cache_name)
-        try:
-            # check cache
-            with open(cache_path, encoding=self.encoding) as f:
-                text = f.read()
-        except FileNotFoundError:
-            # serialize collection
-            if self.get_meta("tag") == "VCALENDAR":
-                collection = vobject.iCalendar()
-                for item in self.get_all():
-                    for content in ("vevent", "vtodo", "vjournal"):
-                        if content in item.contents:
-                            for item_part in getattr(item,
-                                                     "%s_list" % content):
-                                collection.add(item_part)
-                            break
-                text = collection.serialize()
-            elif self.get_meta("tag") == "VADDRESSBOOK":
-                text = "".join(map(lambda x: x.serialize(), self.get_all()))
-            else:
-                text = ""
-            # store in cache
-            self._makedirs_synced(cache_folder)
-            try:
-                # Race: Other processes might have created and locked the file.
-                with self._atomic_write(cache_path, "w") as f:
-                    f.write(text)
-            except PermissionError:
-                pass
-            else:
-                self._clean_cache(cache_folder, filter(
-                    lambda name: name != cache_name, scandir(cache_folder)))
-        return text
+        # serialize collection
+        if self.get_meta("tag") == "VCALENDAR":
+            collection = vobject.iCalendar()
+            for item in self.get_all():
+                for content in ("vevent", "vtodo", "vjournal"):
+                    if content in item.contents:
+                        for item_part in getattr(item,
+                                                 "%s_list" % content):
+                            collection.add(item_part)
+                        break
+            return collection.serialize()
+        elif self.get_meta("tag") == "VADDRESSBOOK":
+            return "".join(map(lambda x: x.serialize(), self.get_all()))
+        return ""
 
     @property
     def etag(self):

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -858,11 +858,14 @@ class Collection(BaseCollection):
                 yield href
 
     def get(self, href):
-        if not is_safe_filesystem_path_component(href):
+        try:
+            if not is_safe_filesystem_path_component(href):
+                raise UnsafePathError(href)
+            path = path_to_filesystem(self._filesystem_path, href)
+        except ValueError as e:
             self.logger.debug("Can't translate name %r safely to filesystem "
-                              "in %r", href, self.path)
+                              "in %r: %s", href, self.path, e, exc_info=True)
             return None
-        path = path_to_filesystem(self._filesystem_path, href)
         if not os.path.isfile(path):
             return None
         with open(path, encoding=self.encoding, newline="") as f:

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -341,6 +341,15 @@ class BaseCollection:
         """
         return map(lambda href: (href, self.get(href)), hrefs)
 
+    def get_all(self):
+        """Fetch all items.
+
+        Functionally similar to ``get``, but might bring performance benefits
+        on some storages when used cleverly.
+
+        """
+        return map(self.get, self.list())
+
     def pre_filtered_list(self, filters):
         """List collection items with optional pre filtering.
 
@@ -348,7 +357,7 @@ class BaseCollection:
         the filters and this implementation.
         This returns all event by default
         """
-        return [self.get(href) for href in self.list()]
+        return self.get_all()
 
     def has(self, href):
         """Check if an item exists by its href.

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -1052,7 +1052,10 @@ class Collection(BaseCollection):
     def etag(self):
         # reuse cached value if the storage is read-only
         if self._writer or self._etag is None:
-            self._etag = super().etag
+            etag = md5()
+            for item in self.get_all():
+                etag.update((item.href + "/" + item.etag).encode("utf-8"))
+            self._etag = '"%s"' % etag.hexdigest()
         return self._etag
 
     _lock = threading.Lock()

--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -406,9 +406,14 @@ class BaseCollection:
 
         This could largely improve performance of reports depending on
         the filters and this implementation.
+
+        Returns tuples in the form ``(item, filters_matched)``.
+        ``filters_matched`` is a bool that indicates if ``filters`` are fully
+        matched.
+
         This returns all event by default
         """
-        return self.get_all()
+        return map(lambda item: (item, False), self.get_all())
 
     def has(self, href):
         """Check if an item exists by its href.
@@ -1032,13 +1037,13 @@ class Collection(BaseCollection):
         tag, start, end = xmlutils.simplify_prefilters(filters)
         if not tag:
             # no filter
-            yield from self.get_all()
+            yield from map(lambda item: (item, False), self.get_all())
             return
         for item, (itag, istart, iend) in map(
                 lambda x: self._get_with_metadata(x, verify_href=False),
                 self.list()):
             if tag == itag and istart < end and iend > start:
-                yield item
+                yield item, False
 
     def upload(self, href, vobject_item):
         if not is_safe_filesystem_path_component(href):

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -1106,7 +1106,7 @@ def report(base_prefix, path, xml_request, collection):
                     continue
             except Exception as e:
                 raise RuntimeError("Failed to filter item %r from %r: %s" %
-                                   (collection.path, item.href, e)) from e
+                                   (item.href, collection.path, e)) from e
 
         found_props = []
         not_found_props = []

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -219,7 +219,7 @@ def _prop_match(item, filter_):
 
 
 def _time_range_match(vobject_item, filter_, child_name):
-    """Check whether the the component/property ``child_name`` of
+    """Check whether the component/property ``child_name`` of
        ``vobject_item`` matches the time-range ``filter_``."""
 
     start = filter_.get("start")

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -58,6 +58,13 @@ for short, url in NAMESPACES.items():
 CLARK_TAG_REGEX = re.compile(r"{(?P<namespace>[^}]*)}(?P<tag>.*)", re.VERBOSE)
 HUMAN_REGEX = re.compile(r"(?P<namespace>[^:{}]*)(?P<tag>.*)", re.VERBOSE)
 
+DAY = timedelta(days=1)
+SECOND = timedelta(seconds=1)
+DATETIME_MIN = datetime.min.replace(tzinfo=timezone.utc)
+DATETIME_MAX = datetime.max.replace(tzinfo=timezone.utc)
+TIMESTAMP_MIN = math.floor(DATETIME_MIN.timestamp())
+TIMESTAMP_MAX = math.ceil(DATETIME_MAX.timestamp())
+
 
 def pretty_xml(element, level=0):
     """Indent an ElementTree ``element`` and its children."""
@@ -263,11 +270,6 @@ def _visit_time_ranges(vobject_item, child_name, range_fn, infinity_fn):
     See rfc4791-9.9.
 
     """
-
-    DAY = timedelta(days=1)
-    SECOND = timedelta(seconds=1)
-    DATETIME_MIN = datetime.min.replace(tzinfo=timezone.utc)
-    DATETIME_MAX = datetime.max.replace(tzinfo=timezone.utc)
     child = getattr(vobject_item, child_name.lower())
     # Comments give the lines in the tables of the specification
     if child_name == "VEVENT":
@@ -505,11 +507,6 @@ def simplify_prefilters(filters):
     and the simplified condition are identical.
 
     """
-
-    TIMESTAMP_MIN = math.floor(
-        datetime.min.replace(tzinfo=timezone.utc).timestamp())
-    TIMESTAMP_MAX = math.ceil(
-        datetime.max.replace(tzinfo=timezone.utc).timestamp())
     flat_filters = tuple(chain.from_iterable(filters))
     simple = len(flat_filters) <= 1
     for col_filter in flat_filters:
@@ -560,9 +557,6 @@ def find_tag_and_time_range(vobject_item):
     This is intened to be used for matching against simplified prefilters.
 
     """
-
-    DATETIME_MIN = datetime.min.replace(tzinfo=timezone.utc)
-    DATETIME_MAX = datetime.max.replace(tzinfo=timezone.utc)
     tag = ""
     if vobject_item.name == "VCALENDAR":
         for component in vobject_item.components():

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -1083,7 +1083,7 @@ def report(base_prefix, path, xml_request, collection):
                     # Reference is a collection
                     collection_requested = True
 
-        for name, item in collection.get_multi(get_names()):
+        for name, item in collection.get_multi2(get_names()):
             if not item:
                 uri = "/" + posixpath.join(collection.path, name)
                 response = _item_response(base_prefix, uri,
@@ -1092,7 +1092,7 @@ def report(base_prefix, path, xml_request, collection):
             else:
                 yield item, False
         if collection_requested:
-            yield from collection.pre_filtered_list(filters)
+            yield from collection.get_all_filtered(filters)
 
     for item, filters_matched in retrieve_items(collection, hreferences,
                                                 multistatus):

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -1085,12 +1085,13 @@ def report(base_prefix, path, xml_request, collection):
                                           found_item=False)
                 multistatus.append(response)
             else:
-                yield item
+                yield item, False
         if collection_requested:
             yield from collection.pre_filtered_list(filters)
 
-    for item in retrieve_items(collection, hreferences, multistatus):
-        if filters:
+    for item, filters_matched in retrieve_items(collection, hreferences,
+                                                multistatus):
+        if filters and not filters_matched:
             match = (
                 _comp_match if collection.get_meta("tag") == "VCALENDAR"
                 else _prop_match)


### PR DESCRIPTION
Big calendars/addressbooks are really slow and requests require a lot of memory. The main reason is vobject. Parsing and serializing with it is slow and it's a memory hog.
This PR reduces the usage of vobject by caching serialization results and metadata for pre-filtering on disk. The memory usage gets further reduced by only keeping one item in memory at a time.

All commits until ``Cache metadata when storage is read-only`` are general improvements. They fix some small bugs, reduce the memory usage by not loading all items at once into memory and fix the slowness that was introduced by collision detection for file system paths.
The following commits improve speed by:
  * Caching the serialization of the whole collection on disk.
  * Caching the serialization of items and metadata (tag, start and end time) for pre-filtering on disk.
  * Caching the etag and metadata of the collection for the duration of the request in memory, if the access is read-only.

This PR is also merged into https://github.com/Unrud/Radicale.

## Benchmark
The tests are performed on a calendar and addressbook with 10,000 files. The approximate memory usage of the requests is noted in brackets.

### Calendar
```
Type:   PROPFIND_getetag (initialize cache)
Before: 15.5 seconds (138,156 kB)
After:  17.8 seconds (    372 kB)

Type:   PROPFIND_getetag
Before: 15.3 seconds (136,604 kB)
After:   0.5 seconds (      0 kB)

Type:   REPORT_calendar-query_getetag
Before: 16.8 seconds (154,180 kB)
After:   1.0 seconds ( 21,964 kB)
PR #586: 1.0 seconds ( 15,356 kB)

Type:   REPORT_calendar-multiget_getetag
Before: 16.4 seconds ( 28,248 kB)
After:   2.1 seconds ( 28,660 kB)
PR #586: 2.2 seconds ( 19,852 kB)

Type:   REPORT_calendar-query_filter-all_getetag
Before: 18.3 seconds (154,448 kB)
After:   1.1 seconds ( 22,332 kB)
PR #586: 1.1 seconds ( 15,092 kB)

Type:   REPORT_calendar-query_filter-none_getetag
Before: 11.0 seconds (133,580 kB)
After:   0.5 seconds (      0 kB)

Type:   GET
Before: 30.5 seconds (138,756 kB)
After:   1.2 seconds (  2,740 kB)
```

### Addressbook
```
Type:   PROPFIND_getetag (initialize cache)
Before:  8.0 seconds ( 69,732 kB)
After:   9.4 seconds (    284 kB)

Type:   PROPFIND_getetag
Before:  8.0 seconds ( 70,020 kB)
After:   0.5 seconds (      0 kB)

Type:   GET
Before: 16.0 seconds ( 70,012 kB)
After:   1.1 seconds (  3,692 kB)
```
**Note:** In all "Before" tests the collision checking for file names was disabled, because it slowed down the requests significantly and made the results less comparable.