### PR TITLE
Add git init to config hook example

### DIFF
--- a/config
+++ b/config
@@ -109,7 +109,7 @@
 #filesystem_close_lock_file = False
 
 # Command that is run after changes to storage
-# Example: git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)
+# Example: ([ -d .git ] || git init) && git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)
 #hook =
 
 


### PR DESCRIPTION
The example code previously required to manually create a git repo first.
Above change automates this.