### PR TITLE
Improve handling of XML requests and responses

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -289,8 +289,10 @@ class Application:
             headers = dict(headers)
             # Set content length
             if answer:
-                self.logger.debug("Response content:\n%s", answer)
-                answer = answer.encode(self.encoding)
+                if hasattr(answer, "encode"):
+                    self.logger.debug("Response content:\n%s", answer)
+                    headers["Content-Type"] += "; charset=%s" % self.encoding
+                    answer = answer.encode(self.encoding)
                 accept_encoding = [
                     encoding.strip() for encoding in
                     environ.get("HTTP_ACCEPT_ENCODING", "").split(",")
@@ -302,7 +304,6 @@ class Application:
                     headers["Content-Encoding"] = "gzip"
 
                 headers["Content-Length"] = str(len(answer))
-                headers["Content-Type"] += "; charset=%s" % self.encoding
 
             # Add extra headers set in configuration
             if self.configuration.has_section("headers"):


### PR DESCRIPTION
  * Move parsing/serialization of XML requests/responses from ``xmlutils.py`` to ``__init__.py``.
  * Log XML requests/responses in pretty-printed form.
      * Previously only the responses were logged in readable form. This is useful for debugging.
      * The XML documents are only converted for pretty-printing if debugging is enabled (it's expensive)
  * Send XML responses in minimized form to clients.
  * Add **encoding** attribute to XML declaration in XML response.
  * Only decode XML requests once. (Previously they were decoded, encoded and decoded again.)

This PR is also merged into https://github.com/Unrud/Radicale.