### PR TITLE
Daemon: Exit first process after server is ready

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -120,7 +120,8 @@ def daemonize(configuration, logger):
         # Check and create PID file in a race-free manner
         if configuration.get("server", "pid"):
             try:
-                pid_path = os.path.abspath(configuration.get("server", "pid"))
+                pid_path = os.path.abspath(os.path.expanduser(
+                    configuration.get("server", "pid")))
                 pid_fd = os.open(
                     pid_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             except OSError as e:

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -114,9 +114,8 @@ def run():
         exit(1)
 
 
-def serve(configuration, logger):
-    """Serve radicale from configuration."""
-    # Fork if Radicale is launched as daemon
+def daemonize(configuration, logger):
+    """Fork and decouple if Radicale is configured as daemon."""
     if configuration.getboolean("server", "daemon"):
         # Check and create PID file in a race-free manner
         if configuration.get("server", "pid"):
@@ -153,6 +152,11 @@ def serve(configuration, logger):
             os.unlink(configuration.get("server", "pid"))
 
     atexit.register(cleanup)
+
+
+def serve(configuration, logger):
+    """Serve radicale from configuration."""
+    daemonize(configuration, logger)
     logger.info("Starting Radicale")
 
     # Create collection servers

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -120,9 +120,9 @@ def daemonize(configuration, logger):
         # Check and create PID file in a race-free manner
         if configuration.get("server", "pid"):
             try:
+                pid_path = os.path.abspath(configuration.get("server", "pid"))
                 pid_fd = os.open(
-                    configuration.get("server", "pid"),
-                    os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                    pid_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             except OSError as e:
                 raise OSError("PID file exists: %s" %
                               configuration.get("server", "pid")) from e
@@ -149,7 +149,7 @@ def daemonize(configuration, logger):
         # Remove PID file
         if (configuration.get("server", "pid") and
                 configuration.getboolean("server", "daemon")):
-            os.unlink(configuration.get("server", "pid"))
+            os.unlink(pid_path)
 
     atexit.register(cleanup)
 

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -123,9 +123,9 @@ def daemonize(configuration, logger):
                 pid_fd = os.open(
                     configuration.get("server", "pid"),
                     os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            except:
-                raise OSError(
-                    "PID file exists: %s" % configuration.get("server", "pid"))
+            except OSError as e:
+                raise OSError("PID file exists: %s" %
+                              configuration.get("server", "pid")) from e
         pid = os.fork()
         if pid:
             sys.exit()

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -128,11 +128,13 @@ def daemonize(configuration, logger):
                               configuration.get("server", "pid")) from e
         pid = os.fork()
         if pid:
+            # Write PID
+            if configuration.get("server", "pid"):
+                with os.fdopen(pid_fd, "w") as pid_file:
+                    pid_file.write(str(pid))
             sys.exit()
-        # Write PID
         if configuration.get("server", "pid"):
-            with os.fdopen(pid_fd, "w") as pid_file:
-                pid_file.write(str(os.getpid()))
+            os.close(pid_fd)
         # Decouple environment
         os.chdir("/")
         os.setsid()

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -158,7 +158,6 @@ def daemonize(configuration, logger):
 
 def serve(configuration, logger):
     """Serve radicale from configuration."""
-    daemonize(configuration, logger)
     logger.info("Starting Radicale")
 
     # Create collection servers
@@ -234,6 +233,7 @@ def serve(configuration, logger):
     else:
         # Fallback to busy waiting
         select_timeout = 1.0
+    daemonize(configuration, logger)
     logger.debug("Radicale server ready")
     while not shutdown_program:
         try:

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -116,45 +116,41 @@ def run():
 
 def daemonize(configuration, logger):
     """Fork and decouple if Radicale is configured as daemon."""
-    if configuration.getboolean("server", "daemon"):
-        # Check and create PID file in a race-free manner
+    # Check and create PID file in a race-free manner
+    if configuration.get("server", "pid"):
+        try:
+            pid_path = os.path.abspath(os.path.expanduser(
+                configuration.get("server", "pid")))
+            pid_fd = os.open(
+                pid_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except OSError as e:
+            raise OSError("PID file exists: %s" %
+                          configuration.get("server", "pid")) from e
+    pid = os.fork()
+    if pid:
+        # Write PID
         if configuration.get("server", "pid"):
-            try:
-                pid_path = os.path.abspath(os.path.expanduser(
-                    configuration.get("server", "pid")))
-                pid_fd = os.open(
-                    pid_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            except OSError as e:
-                raise OSError("PID file exists: %s" %
-                              configuration.get("server", "pid")) from e
-        pid = os.fork()
-        if pid:
-            # Write PID
-            if configuration.get("server", "pid"):
-                with os.fdopen(pid_fd, "w") as pid_file:
-                    pid_file.write(str(pid))
-            sys.exit()
-        if configuration.get("server", "pid"):
-            os.close(pid_fd)
-        # Decouple environment
-        os.chdir("/")
-        os.setsid()
-        with open(os.devnull, "r") as null_in:
-            os.dup2(null_in.fileno(), sys.stdin.fileno())
-        with open(os.devnull, "w") as null_out:
-            os.dup2(null_out.fileno(), sys.stdout.fileno())
-            os.dup2(null_out.fileno(), sys.stderr.fileno())
+            with os.fdopen(pid_fd, "w") as pid_file:
+                pid_file.write(str(pid))
+        sys.exit()
+    if configuration.get("server", "pid"):
+        os.close(pid_fd)
 
-    # Register exit function
-    def cleanup():
-        """Remove the PID files."""
-        logger.debug("Cleaning up")
-        # Remove PID file
-        if (configuration.get("server", "pid") and
-                configuration.getboolean("server", "daemon")):
+        # Register exit function
+        def cleanup():
+            """Remove the PID files."""
+            logger.debug("Cleaning up")
+            # Remove PID file
             os.unlink(pid_path)
-
-    atexit.register(cleanup)
+        atexit.register(cleanup)
+    # Decouple environment
+    os.chdir("/")
+    os.setsid()
+    with open(os.devnull, "r") as null_in:
+        os.dup2(null_in.fileno(), sys.stdin.fileno())
+    with open(os.devnull, "w") as null_out:
+        os.dup2(null_out.fileno(), sys.stdout.fileno())
+        os.dup2(null_out.fileno(), sys.stderr.fileno())
 
 
 def serve(configuration, logger):
@@ -234,7 +230,8 @@ def serve(configuration, logger):
     else:
         # Fallback to busy waiting
         select_timeout = 1.0
-    daemonize(configuration, logger)
+    if configuration.getboolean("server", "daemon"):
+        daemonize(configuration, logger)
     logger.debug("Radicale server ready")
     while not shutdown_program:
         try:


### PR DESCRIPTION
Daemonize after the sockets are created and write PID in first process.
This ensure that the server is ready and the PID file can be read, when the first process exits.
See also https://www.freedesktop.org/software/systemd/man/daemon.html#SysV%20Daemons

This also fixes a bug with relative PID file paths. The daemon was not able to cleanup the file, because the current directory is set to root.

This PR is also merged into https://github.com/Unrud/Radicale.