### PR TITLE
Test and fix auth module. Configurable delay. Improve logging.

### DIFF
--- a/config
+++ b/config
@@ -78,6 +78,9 @@
 # bcrypt and md5 require the passlib library to be installed.
 #htpasswd_encryption = bcrypt
 
+# Incorrect authentication delay (seconds)
+#delay = 1
+
 
 [rights]
 

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -34,11 +34,13 @@ import itertools
 import os
 import posixpath
 import pprint
+import random
 import socket
 import socketserver
 import ssl
 import sys
 import threading
+import time
 import traceback
 import wsgiref.simple_server
 import zlib
@@ -383,6 +385,13 @@ class Application:
             is_authenticated = False
         else:
             is_authenticated = self.Auth.is_authenticated(user, password)
+            if not is_authenticated:
+                # Random delay to avoid timing oracles and bruteforce attacks
+                delay = self.configuration.getfloat("auth", "delay")
+                if delay > 0:
+                    random_delay = delay * (0.5 + random.random())
+                    self.logger.debug("Sleeping %.3f seconds", random_delay)
+                    time.sleep(random_delay)
 
         # Create principal collection
         if user and is_authenticated:

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -375,13 +375,14 @@ class Application:
         if path == "/.well-known" or path.startswith("/.well-known/"):
             return response(*NOT_FOUND)
 
-        if user and not storage.is_safe_path_component(user):
+        if not user:
+            is_authenticated = True
+        elif not storage.is_safe_path_component(user):
             # Prevent usernames like "user/calendar.ics"
             self.logger.info("Refused unsafe username: %s", user)
             is_authenticated = False
         else:
             is_authenticated = self.Auth.is_authenticated(user, password)
-        is_valid_user = is_authenticated or not user
 
         # Create principal collection
         if user and is_authenticated:
@@ -405,7 +406,7 @@ class Application:
                     "Request body too large: %d", content_length)
                 return response(*REQUEST_ENTITY_TOO_LARGE)
 
-        if is_valid_user:
+        if is_authenticated:
             try:
                 status, headers, answer = function(
                     environ, base_prefix, path, user)

--- a/radicale/auth.py
+++ b/radicale/auth.py
@@ -58,8 +58,6 @@ import functools
 import hashlib
 import hmac
 import os
-import random
-import time
 from importlib import import_module
 
 
@@ -198,6 +196,4 @@ class Auth(BaseAuth):
                     login, hash_value = line.split(":")
                     if login == user and self.verify(hash_value, password):
                         return True
-        # Random timer to avoid timing oracles and simple bruteforce attacks
-        time.sleep(1 + random.random())
         return False

--- a/radicale/auth.py
+++ b/radicale/auth.py
@@ -169,11 +169,11 @@ class Auth(BaseAuth):
         written with e.g. openssl, and nginx can parse it.
 
         """
-        hash_value = hash_value.replace(
-            "{SSHA}", "").encode("ascii").decode("base64")
+        hash_value = base64.b64decode(hash_value.replace(
+            "{SSHA}", "").encode("ascii"))
         password = password.encode(self.configuration.get("encoding", "stock"))
-        hash_value = hash_value[:20]
         salt_value = hash_value[20:]
+        hash_value = hash_value[:20]
         sha1 = hashlib.sha1()
         sha1.update(password)
         sha1.update(salt_value)

--- a/radicale/auth.py
+++ b/radicale/auth.py
@@ -56,6 +56,7 @@ following significantly more secure schemes are parsable by Radicale:
 import base64
 import functools
 import hashlib
+import hmac
 import os
 import random
 import time
@@ -148,11 +149,12 @@ class Auth(BaseAuth):
 
     def _plain(self, hash_value, password):
         """Check if ``hash_value`` and ``password`` match, plain method."""
-        return hash_value == password
+        return hmac.compare_digest(hash_value, password)
 
     def _crypt(self, crypt, hash_value, password):
         """Check if ``hash_value`` and ``password`` match, crypt method."""
-        return crypt.crypt(password, hash_value) == hash_value
+        return hmac.compare_digest(crypt.crypt(password, hash_value),
+                                   hash_value)
 
     def _sha1(self, hash_value, password):
         """Check if ``hash_value`` and ``password`` match, sha1 method."""
@@ -160,7 +162,7 @@ class Auth(BaseAuth):
         password = password.encode(self.configuration.get("encoding", "stock"))
         sha1 = hashlib.sha1()
         sha1.update(password)
-        return sha1.digest() == base64.b64decode(hash_value)
+        return hmac.compare_digest(sha1.digest(), base64.b64decode(hash_value))
 
     def _ssha(self, hash_value, password):
         """Check if ``hash_value`` and ``password`` match, salted sha1 method.
@@ -177,7 +179,7 @@ class Auth(BaseAuth):
         sha1 = hashlib.sha1()
         sha1.update(password)
         sha1.update(salt_value)
-        return sha1.digest() == hash_value
+        return hmac.compare_digest(sha1.digest(), hash_value)
 
     def _bcrypt(self, bcrypt, hash_value, password):
         return bcrypt.verify(password, hash_value)

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -93,7 +93,10 @@ INITIAL_CONFIG = OrderedDict([
             "help": "htpasswd filename"}),
         ("htpasswd_encryption", {
             "value": "bcrypt",
-            "help": "htpasswd encryption method"})])),
+            "help": "htpasswd encryption method"}),
+        ("delay", {
+            "value": "1",
+            "help": "incorrect authentication delay"})])),
     ("rights", OrderedDict([
         ("type", {
             "value": "owner_only",

--- a/radicale/tests/test_auth.py
+++ b/radicale/tests/test_auth.py
@@ -47,6 +47,8 @@ class TestBaseAuthRequests(BaseTest):
         self.configuration.set("storage", "filesystem_fsync", "False")
         # Required on Windows, doesn't matter on Unix
         self.configuration.set("storage", "close_lock_file", "True")
+        # Set incorrect authentication delay to a very low value
+        self.configuration.set("auth", "delay", "0.002")
 
     def teardown(self):
         shutil.rmtree(self.colpath)


### PR DESCRIPTION
  * Repair the tests for the auth module (they were not working at all).
  * Add tests for all hash methods and also test with wrong usernames and passwords.
  * Fix the SSHA method.
  * Compare in constant time.
  * Add configuration option for the delay.
  * Don't apply the delay for clients that didn't try to authenticate.

This PR is also merged into https://github.com/Unrud/Radicale.