### PR TITLE
Disable logging config by default

### DIFF
--- a/config
+++ b/config
@@ -122,7 +122,7 @@
 # If no config is given, simple information is printed on the standard output
 # For more information about the syntax of the configuration file, see:
 # http://docs.python.org/library/logging.config.html
-#config = /etc/radicale/logging
+#config =
 
 # Set the default logging level to debug
 #debug = False

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -123,7 +123,7 @@ INITIAL_CONFIG = OrderedDict([
             "help": "command that is run after changes to storage"})])),
     ("logging", OrderedDict([
         ("config", {
-            "value": "/etc/radicale/logging",
+            "value": "",
             "help": "logging configuration file"}),
         ("debug", {
             "value": "False",


### PR DESCRIPTION
Radicale always tries to load the system-wide configuration file. To turn this off, the logging-config option has to be added to all configuration files and command line arguments. It's easier to disable it by default and only enable it once in the system-wide config file.