### PR TITLE
Move "realm" configuration from "server" to "auth" section

### DIFF
--- a/config
+++ b/config
@@ -50,9 +50,6 @@
 # Reverse DNS to resolve client address in logs
 #dns_lookup = True
 
-# Message displayed in the client when a password is needed
-#realm = Radicale - Password Required
-
 
 [encoding]
 
@@ -80,6 +77,9 @@
 
 # Incorrect authentication delay (seconds)
 #delay = 1
+
+# Message displayed in the client when a password is needed
+#realm = Radicale - Password Required
 
 
 [rights]

--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -433,7 +433,7 @@ class Application:
             # Unknown or unauthorized user
             self.logger.debug("Asking client for authentication")
             status = client.UNAUTHORIZED
-            realm = self.configuration.get("server", "realm")
+            realm = self.configuration.get("auth", "realm")
             headers = dict(headers)
             headers.update({
                 "WWW-Authenticate":

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -73,10 +73,7 @@ INITIAL_CONFIG = OrderedDict([
             "help": "available ciphers"}),
         ("dns_lookup", {
             "value": "True",
-            "help": "use reverse DNS to resolve client address in logs"}),
-        ("realm", {
-            "value": "Radicale - Password Required",
-            "help": "message displayed when a password is needed"})])),
+            "help": "use reverse DNS to resolve client address in logs"})])),
     ("encoding", OrderedDict([
         ("request", {
             "value": "utf-8",
@@ -96,7 +93,10 @@ INITIAL_CONFIG = OrderedDict([
             "help": "htpasswd encryption method"}),
         ("delay", {
             "value": "1",
-            "help": "incorrect authentication delay"})])),
+            "help": "incorrect authentication delay"}),
+        ("realm", {
+            "value": "Radicale - Password Required",
+            "help": "message displayed when a password is needed"})])),
     ("rights", OrderedDict([
         ("type", {
             "value": "owner_only",


### PR DESCRIPTION
All configuration options in the ``server`` section should only affect the standalone server.