### PR TITLE
Fail if config file is not found

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -74,9 +74,12 @@ def run():
                 group.add_argument(*args, **kwargs)
 
     args = parser.parse_args()
-    if args.config:
+    if args.config is not None:
         configuration = config.load()
-        configuration_found = configuration.read(args.config)
+        if args.config:
+            configuration_found = configuration.read(args.config)
+        else:
+            configuration_found = True
     else:
         configuration_paths = [
             "/etc/radicale/config",
@@ -101,7 +104,8 @@ def run():
 
     # Log a warning if the configuration file of the command line is not found
     if not configuration_found:
-        logger.warning("Configuration file '%s' not found" % args.config)
+        logger.error("Configuration file '%s' not found" % args.config)
+        exit(1)
 
     try:
         serve(configuration, logger)


### PR DESCRIPTION
If a configuration file is passed with a command line argument and the file is not found, Radicale shows a warning and continues with the default configuration.
There is no reason for doing this, Radicale should just fail.

Instead, this PR allows passing an empty string like ``--config ""``. Radicale will use the default configuration in this case, without trying to load the configuration from the common paths. Previously you had to do specify a path that doesn't exist like ``--config /does/not/exist``, which looks ugly and showed a warning message.