### PR TITLE
Preserve empty PATH_INFO from WSGI and strip base prefix from destination

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -466,10 +466,6 @@ class Collection(BaseCollection):
 
     @classmethod
     def discover(cls, path, depth="0"):
-        if path is None:
-            # Wrong URL
-            return
-
         # Path should already be sanitized
         sane_path = sanitize_path(path).strip("/")
         attributes = sane_path.split("/")


### PR DESCRIPTION
The first is required for correct redirects in the web interface and the latter was forgotten.