### PR TITLE
Allow auth backends to provide login and password

### DIFF
--- a/config
+++ b/config
@@ -66,7 +66,7 @@
 [auth]
 
 # Authentication method
-# Value: None | htpasswd
+# Value: None | htpasswd | remote_user | http_x_remote_user
 #type = None
 
 # Htpasswd filename

--- a/radicale/auth.py
+++ b/radicale/auth.py
@@ -67,6 +67,10 @@ def load(configuration, logger):
     logger.debug("Authentication type is %s", auth_type)
     if auth_type == "None":
         class_ = NoneAuth
+    elif auth_type == "remote_user":
+        class_ = RemoteUserAuth
+    elif auth_type == "http_x_remote_user":
+        class_ = HttpXRemoteUserAuth
     elif auth_type == "htpasswd":
         class_ = Auth
     else:
@@ -78,6 +82,14 @@ class BaseAuth:
     def __init__(self, configuration, logger):
         self.configuration = configuration
         self.logger = logger
+
+    def get_external_login(self, environ):
+        """Optionally provide the login and password externally.
+
+        Returns a tuple (login, password) or ().
+
+        """
+        return ()
 
     def is_authenticated(self, user, password):
         """Validate credentials.
@@ -201,3 +213,13 @@ class Auth(BaseAuth):
                     if login_ok & password_ok:
                         return True
         return False
+
+
+class RemoteUserAuth(NoneAuth):
+    def get_external_login(self, environ):
+        return environ.get("REMOTE_USER", ""), ""
+
+
+class HttpXRemoteUserAuth(NoneAuth):
+    def get_external_login(self, environ):
+        return environ.get("HTTP_X_REMOTE_USER", ""), ""

--- a/radicale/tests/test_auth.py
+++ b/radicale/tests/test_auth.py
@@ -109,6 +109,34 @@ class TestBaseAuthRequests(BaseTest):
             "bcrypt",
             "tmp:$2y$05$oD7hbiQFQlvCM7zoalo/T.MssV3VNTRI3w5KDnj8NTUKJNWfVpvRq")
 
+    def test_remote_user(self):
+        self.configuration.set("auth", "type", "remote_user")
+        self.application = Application(self.configuration, self.logger)
+        status, _, answer = self.request(
+            "PROPFIND", "/",
+            """<?xml version="1.0" encoding="utf-8"?>
+               <propfind xmlns="DAV:">
+                 <prop>
+                   <current-user-principal />
+                 </prop>
+               </propfind>""", REMOTE_USER="test")
+        assert status == 207
+        assert ">/test/<" in answer
+
+    def test_http_x_remote_user(self):
+        self.configuration.set("auth", "type", "http_x_remote_user")
+        self.application = Application(self.configuration, self.logger)
+        status, _, answer = self.request(
+            "PROPFIND", "/",
+            """<?xml version="1.0" encoding="utf-8"?>
+               <propfind xmlns="DAV:">
+                 <prop>
+                   <current-user-principal />
+                 </prop>
+               </propfind>""", HTTP_X_REMOTE_USER="test")
+        assert status == 207
+        assert ">/test/<" in answer
+
     def test_custom(self):
         """Custom authentication."""
         self.configuration.set("auth", "type", "tests.custom.auth")


### PR DESCRIPTION
This is used to implement an auth backend that takes the credentials from an HTTP header (e.g. accounts are managed by an reverse proxy).