### PR TITLE
raise exception when locking the storage fails

### DIFF
--- a/config
+++ b/config
@@ -101,6 +101,10 @@
 # Folder for storing local collections, created if not present
 #filesystem_folder = /var/lib/radicale/collections
 
+# Lock the storage. Never start multiple instances of Radicale or edit the
+# storage externally while Radicale is running if disabled.
+#filesystem_locking = True
+
 # Sync all changes to disk during requests. (This can impair performance.)
 # Disabling it increases the risk of data loss, when the system crashes or
 # power fails!

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -32,9 +32,8 @@ import ssl
 import sys
 from wsgiref.simple_server import make_server
 
-from . import (
-    VERSION, Application, RequestHandler, ThreadedHTTPServer,
-    ThreadedHTTPSServer, config, log)
+from . import (VERSION, Application, RequestHandler, ThreadedHTTPServer,
+               ThreadedHTTPSServer, config, log)
 
 
 def run():

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -139,6 +139,10 @@ INITIAL_CONFIG = OrderedDict([
             "value": "True",
             "help": "sync all changes to filesystem during requests",
             "type": bool}),
+        ("filesystem_locking", {
+            "value": "True",
+            "help": "lock the storage while accessing it",
+            "type": bool}),
         ("filesystem_close_lock_file", {
             "value": "False",
             "help": "close the lock file when no more clients are waiting",

--- a/radicale/tests/test_auth.py
+++ b/radicale/tests/test_auth.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 
 import pytest
+
 from radicale import Application, config
 
 from .test_base import BaseTest

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 
 import pytest
+
 from radicale import Application, config
 
 from . import BaseTest


### PR DESCRIPTION
Previously it was silently ignored, which is dangerous when multiple instances of Radicale are running.
A configuration option to disable locking was added.