### PR TITLE
Add option for CA certificate for validating clients

### DIFF
--- a/config
+++ b/config
@@ -41,6 +41,10 @@
 # SSL private key
 #key = /etc/ssl/radicale.key.pem
 
+# CA certificate for validating clients. This can be used to secure
+# TCP traffic between Radicale and a reverse proxy
+#certificate_authority =
+
 # SSL Protocol used. See python's ssl module for available values
 #protocol = PROTOCOL_TLSv1_2
 

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -169,11 +169,15 @@ def serve(configuration, logger):
         server_class = ThreadedHTTPSServer
         server_class.certificate = configuration.get("server", "certificate")
         server_class.key = configuration.get("server", "key")
+        server_class.certificate_authority = configuration.get(
+            "server", "certificate_authority")
         server_class.ciphers = configuration.get("server", "ciphers")
         server_class.protocol = getattr(
             ssl, configuration.get("server", "protocol"), ssl.PROTOCOL_SSLv23)
         # Test if the SSL files can be read
-        for name in ("certificate", "key"):
+        for name in ["certificate", "key"] + (
+                ["certificate_authority"]
+                if server_class.certificate_authority else []):
             filename = getattr(server_class, name)
             try:
                 open(filename, "r").close()

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -74,6 +74,11 @@ INITIAL_CONFIG = OrderedDict([
             "help": "set private key file",
             "aliases": ["-k", "--key"],
             "type": str}),
+        ("certificate_authority", {
+            "value": "",
+            "help": "set CA certificate for validating clients",
+            "aliases": ["--certificate-authority"],
+            "type": str}),
         ("protocol", {
             "value": "PROTOCOL_TLSv1_2",
             "help": "SSL protocol used",


### PR DESCRIPTION
This can be used to secure TCP traffic between Radicale and a reverse proxy