### PR TITLE
Tell users that the website is in branch gh-pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,6 @@
 <footer>
   <ul>
     <li><a href="http://kozea.fr">Made with ❤ by Kozea</a></li>
-    <li><a href="{{ site.github.repository_url }}">Fork me on GitHub</a></li>
+    <li><a href="{{ site.github.repository_url }}">Fork me on GitHub (code is in branch master and others, website in branch gh-pages</a></li>
   </ul>
 </footer>


### PR DESCRIPTION
Hi,
I just created a pull request for two minor typos on the website. My experience in doing this task the first time was not optimal:
First it took me a while to have the idea that the website itself might be in git ("..., hmm, don't github projects have their website in git?")
Of course in the default view (branch master) there was nothing.
"Err, of course, either another repo or another branch ... . Ah, there it is, branch *website*. ... Hmm, no. .... Ah, branch *gh-pages*"
Done, problem solved, will work perfectly in the future.

Therefore I suggest to make the facts
* that the website itself is in git and
* that it is in branch "gh-pages"
known to users on every page. I'm not really happy with my proposed solution, better suggestions welcome. Ideally you'd add a second link, expanding the href "site.github.repository_url" with a branch.

Greets