### PR TITLE
Skip comment lines in htpasswd files

### DIFF
--- a/radicale/auth.py
+++ b/radicale/auth.py
@@ -211,6 +211,8 @@ class Auth(BaseAuth):
         try:
             with open(self.filename) as fd:
                 for line in fd:
+                    if line.startswith("#"):
+                        continue
                     line = line.strip()
                     if line:
                         try:


### PR DESCRIPTION
Some webservers like [nginx](https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html#auth_basic_user_file) support comments in htpasswd files. Afaik Apache itself does not allow this.

In either way I think this would be a really useful feature for organising the accounts inside the htpasswd file a little, whilst it neither makes the code much more complicated nor any slower ;).