### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ VOLUME /etc/radicale
 # TCP port of Radicale (Publish it on a host interface!)
 EXPOSE 5232
 # Run Radicale (Configure it here or provide a "config" file!)
-CMD ["radicale", "--hosts", "0.0.0.0:5232"]
+ENTRYPOINT ["/srv/radicale/docker/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:latest
 
+# For documentation see docker folder
+
 # Install dependencies
 RUN apk add --no-cache \
       ca-certificates \
@@ -18,11 +20,8 @@ ADD . /srv/radicale/
 
 # Install Radicale
 RUN python3 -m pip install /srv/radicale
-# Persistent storage for data (Mount it somewhere on the host!)
+
 VOLUME /var/lib/radicale
-# Configuration data (Put the "config" file here!)
 VOLUME /etc/radicale
-# TCP port of Radicale (Publish it on a host interface!)
 EXPOSE 5232
-# Run Radicale (Configure it here or provide a "config" file!)
 ENTRYPOINT ["/srv/radicale/docker/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM alpine:latest
 
-# Version of Radicale (e.g. 2.0.0)
-ARG VERSION=master
-
 # Install dependencies
 RUN apk add --no-cache \
       ca-certificates \
@@ -16,11 +13,11 @@ RUN apk add --no-cache \
       bcrypt \
       passlib && \
     apk del .deps
+
+ADD . /srv/radicale/
+
 # Install Radicale
-RUN wget --quiet https://github.com/Kozea/Radicale/archive/${VERSION}.tar.gz --output-document=radicale.tar.gz && \
-    tar xzf radicale.tar.gz && \
-    python3 -m pip install ./Radicale-${VERSION} && \
-    rm -r radicale.tar.gz Radicale-${VERSION}
+RUN python3 -m pip install /srv/radicale
 # Persistent storage for data (Mount it somewhere on the host!)
 VOLUME /var/lib/radicale
 # Configuration data (Put the "config" file here!)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,17 @@ ARG VERSION=master
 
 # Install dependencies
 RUN apk add --no-cache \
-      python3 \
-      python3-dev \
+      ca-certificates \
+      openssl \
+      python3 && \
+    apk add --no-cache --virtual .deps \
       build-base \
       libffi-dev \
-      ca-certificates \
-      openssl && \
-    python3 -m pip install passlib bcrypt && \
-    apk del \
-      python3-dev \
-      build-base \
-      libffi-dev
+      python3-dev && \
+    python3 -m pip install \
+      bcrypt \
+      passlib && \
+    apk del .deps
 # Install Radicale
 RUN wget --quiet https://github.com/Kozea/Radicale/archive/${VERSION}.tar.gz --output-document=radicale.tar.gz && \
     tar xzf radicale.tar.gz && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,33 @@
+# Radicale docker image
+
+# Build the image
+
+1. Change into the root directory of the repo.
+1. `docker build -t radicale .`
+
+# Running the image
+
+```bash
+docker run --rm \
+    -v $PWD/lib:/var/lib/radicale \
+    -v $PWD/conf:/etc/radicale:ro \
+    radicale
+```
+
+This image neither features HTTPS or a webserver. It's recommended to use a reverse proxy in front of it.
+
+# Reference
+
+## Parameters
+
+- `RADICALE_UID`: The user id of the internal radicale user
+- `RADICALE_UID`: The group id of the internal radicale group
+
+## Volumes
+
+- `/var/lib/radicale`: data files
+- `/etc/radicale`: Radicale configuration (put the configuration file here)
+
+## Ports
+
+- `5323`: Main radicale port

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RADICALE_UID="${RADICALE_UID:-1000}"
+RADICALE_GID="${RADICALE_GID:-1000}"
+
+addgroup   -g ${RADICALE_GID} radicale
+adduser -D -s /bin/false -u ${RADICALE_GID} -G radicale radicale
+
+chown -R radicale:radicale "$(dirname "${RADICALE_CONFIG:-/etc/radicale/radicale.config}")" /var/lib/radicale
+
+su - radicale -s /bin/sh -c "radicale --hosts 0.0.0.0:5232 ${RADICALE_CONFIG:+--config='${RADICALE_CONFIG}'} $*"


### PR DESCRIPTION
Like many others, I'd like to see a docker image from Kozea on docker hub (#522). I'm not talking about a docker library image (which often also get called official image).

On the first step, there are some neccessary technical changes. As dockerhub builds out of the git repository and handles git tags transparently in combination with docker image tags, the Dockerfile should build from the gitrepo and not download from github master again.

Also, I added an entrypoint, which executes radicale as a normal user and also sorted the package lists (as recommended in [dockerfile's best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/)).

---

After merging this, it should be a quite easy move to create an organization on dockerhub with an automated build repo.