### PR TITLE
Update alpine's apk before installing packages in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM alpine:latest
 ARG VERSION=master
 
 # Install dependencies
-RUN apk add --no-cache \
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache \
       python3 \
       python3-dev \
       build-base \


### PR DESCRIPTION
In the Dockerfile, `apk` was not updated before installing the dependencies for Radicale.

Today or yesterday I started getting SSL errors when using Radicale with HTTPS:

```
[7f725c276ae8] ERROR: An exception occurred during request: SSL handshake failed: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:777)
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/radicale/__init__.py", line 182, in process_request_thread
    request.do_handshake()
  File "/usr/lib/python3.6/ssl.py", line 1068, in do_handshake
    self._sslobj.do_handshake()
  File "/usr/lib/python3.6/ssl.py", line 689, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:777)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/radicale/__init__.py", line 186, in process_request_thread
    raise RuntimeError("SSL handshake failed: %s" % e) from e
RuntimeError: SSL handshake failed: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:777)
```

This looked like it was caused by an old version of SSL. Updating `apk` in the Dockerfile before installing the `openssl` requirement seems to have fixed this.

This probably also fixes #794.

(Don't forget to re-build the Docker image before testing.)