### PR TITLE
support HTTP_X_PATH_INFO

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -405,6 +405,8 @@ class Application:
             unsafe_base_prefix = environ["HTTP_X_SCRIPT_NAME"]
             self.logger.debug("Script name overwritten by client: %r",
                               unsafe_base_prefix)
+            if "HTTP_X_PATH_INFO" in environ:
+                environ["PATH_INFO"] = environ["HTTP_X_PATH_INFO"]
         else:
             # SCRIPT_NAME is already removed from PATH_INFO, according to the
             # WSGI specification.


### PR DESCRIPTION
there is an issue by detecting PATH_INFO like described in #803 
In Apache mod_proxy_fcgi module >=2.4.26 is a possibility to set / override PATH_INFO and SCRIPT_NAME per `ProxyFCGISetEnvIf` directive.
this patch allows to override PATH_INFO with HTTP_X_PATH_INFO for earlier versions and more restrictive setups.