### PR TITLE
fix datetime parsing

### DIFF
--- a/radicale_vobject/icalendar.py
+++ b/radicale_vobject/icalendar.py
@@ -12,6 +12,8 @@ import base64
 from dateutil import rrule, tz
 import six
 
+from dateutil import parser
+
 try:
     import pytz
 except ImportError:
@@ -1717,32 +1719,17 @@ def isDuration(s):
 
 
 def stringToDate(s):
-    year = int(s[0:4])
-    month = int(s[4:6])
-    day = int(s[6:8])
-    return datetime.date(year, month, day)
+    return parser.parse(s)
 
 
 def stringToDateTime(s, tzinfo=None):
     """
     Returns datetime.datetime object.
     """
-    try:
-        year = int(s[0:4])
-        month = int(s[4:6])
-        day = int(s[6:8])
-        hour = int(s[9:11])
-        minute = int(s[11:13])
-        second = int(s[13:15])
-        if len(s) > 15:
-            if s[15] == 'Z':
-                tzinfo = getTzid('UTC')
-    except:
-        raise ParseError("'{0!s}' is not a valid DATE-TIME".format(s))
-    year = year and year or 2000
-    if tzinfo is not None and hasattr(tzinfo,'localize'):  # PyTZ case
-        return tzinfo.localize(datetime.datetime(year, month, day, hour, minute, second))
-    return datetime.datetime(year, month, day, hour, minute, second, 0, tzinfo)
+    dt = parser.parse(s)
+    if tzinfo is not None:
+        dt = tzinfo.localize(dt)
+    return dt
 
 
 # DQUOTE included to work around iCal's penchant for backslash escaping it,


### PR DESCRIPTION
Hello!

Just started Radicale in Docker and found that dates coming from DAVDroid are not parsed correctly.
Did not tested on other clients yet, so, perhaps it is not relevant to them.