### PR TITLE
Add missing cls paramter to class method.

### DIFF
--- a/radicale/storage.py
+++ b/radicale/storage.py
@@ -510,7 +510,7 @@ class BaseCollection:
     path = ""
 
     @classmethod
-    def static_init():
+    def static_init(cls):
         """init collection copy"""
         pass
 


### PR DESCRIPTION
This fixes a bug introduced in 2.1.10. It was essentially causing Radicale to
break if the storage backend didn't not implement the newly added class
function.
This broke the EteSync backend.