### PR TITLE
[RFC][rights] Allow slash in sane_path

### DIFF
--- a/radicale/rights/authenticated.py
+++ b/radicale/rights/authenticated.py
@@ -30,6 +30,6 @@ class Rights(rights.BaseRights):
         sane_path = pathutils.strip_path(path)
         if "/" not in sane_path:
             return rights.intersect_permissions(permissions, "RW")
-        if sane_path.count("/") == 1:
+        if sane_path.count("/") >= 1:
             return rights.intersect_permissions(permissions, "rw")
         return ""

--- a/radicale/rights/owner_only.py
+++ b/radicale/rights/owner_only.py
@@ -30,6 +30,6 @@ class Rights(authenticated.Rights):
             return ""
         if "/" not in sane_path:
             return rights.intersect_permissions(permissions, "RW")
-        if sane_path.count("/") == 1:
+        if sane_path.count("/") >= 1:
             return rights.intersect_permissions(permissions, "rw")
         return ""

--- a/radicale/rights/owner_write.py
+++ b/radicale/rights/owner_write.py
@@ -33,7 +33,7 @@ class Rights(authenticated.Rights):
         if "/" not in sane_path:
             return rights.intersect_permissions(permissions,
                                                 "RW" if owned else "R")
-        if sane_path.count("/") == 1:
+        if sane_path.count("/") >= 1:
             return rights.intersect_permissions(permissions,
                                                 "rw" if owned else "r")
         return ""


### PR DESCRIPTION
If the sane_path contains more then one slash, the rights backend
blocked the access, instead of granting rw permissions.