### PR TITLE
Encryption for ics files

### DIFF
--- a/config
+++ b/config
@@ -106,6 +106,9 @@
 # Example: ([ -d .git ] || git init) && git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)
 #hook =
 
+#Encrypt the ics files with AES256?
+#You can only specifiy this *before* you commit your first calendar entry
+encrypt = True
 
 [web]
 

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -168,7 +168,11 @@ INITIAL_CONFIG = OrderedDict([
         ("hook", {
             "value": "",
             "help": "command that is run after changes to storage",
-            "type": str})])),
+            "type": str}),
+        ("encrypt", {
+            "value": "False",
+            "help": "encrypt .ics files with AES256",
+            "type": bool})])),
     ("web", OrderedDict([
         ("type", {
             "value": "internal",

--- a/radicale/storage/multifilesystem/get.py
+++ b/radicale/storage/multifilesystem/get.py
@@ -31,11 +31,6 @@ from radicale import pathutils
 from radicale.log import logger
 
 
-from Crypto.Cipher import AES
-from Crypto import Random
-import hashlib
-import binascii
-
 class CollectionGetMixin:
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Added support to encrypt the .ics files with AES256 in CFB mode. The resulting byte output from the encryption process is converted to a string so that the read function doesnt throw any errors. The IV is stored at the head of the encrypted file. The bcrypt encrypted password is sha256'ed to create a 32 bit long key for the encryption. I didnt implement a KDF because the keys are already stored in a safe way.

This option is only changeable before your first calendar entry, I havent implemented a conversion tool.
I expanded the programm because I have a couple of users in my server accessing the radicale server and I didnt want me to be able to read the calendar entries of other people.

This is my first contribution to an open source project, so I am not sure the code I wrote is considered 'good' :)