### PR TITLE
Add manual import of existing calendar to documentation

### DIFF
--- a/clients.md
+++ b/clients.md
@@ -159,3 +159,11 @@ Delete the collections by running something like:
 ```shell
 $ curl -u user -X DELETE 'http://localhost:5232/user/calendar'
 ```
+
+## Manual import of existing calendar
+
+To import an already existing calendar, download its ics file then :
+
+```shell
+curl -L -u "user" -X PUT http://localhost:5232/user/calendar --data-binary @calendar.ics
+```


### PR DESCRIPTION
Hello,
I had to import an existing calendar, but I didn't find an how to in the documentation.
Based on your reply here : https://github.com/Kozea/Radicale/issues/750 I added the curl command in clients.md to import an ics file.