### PR TITLE
Using a `rights` file breaks the web login

### DIFF
--- a/radicale/web/internal_data/fn.js
+++ b/radicale/web/internal_data/fn.js
@@ -121,7 +121,7 @@ function Collection(href, type, displayname, description, color) {
  */
 function get_principal(user, password, callback) {
     var request = new XMLHttpRequest();
-    request.open("PROPFIND", SERVER + ROOT_PATH, true, user, password);
+    request.open("PROPFIND", SERVER + ROOT_PATH + user, true, user, password);
     request.onreadystatechange = function() {
         if (request.readyState !== 4) {
             return;


### PR DESCRIPTION
Using a `rights` file breaks the web login https://www.myserver.com:5232. This commit should resolve #898.

Note: It is not thoroughly tested, but works for me with and without `rights`
file.