### PR TITLE
Introduced dovecot authN module

### DIFF
--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -58,7 +58,9 @@ from importlib import import_module
 
 from radicale.log import logger
 
-INTERNAL_TYPES = ("none", "remote_user", "http_x_remote_user", "htpasswd")
+INTERNAL_TYPES = (
+        "none", "remote_user", "http_x_remote_user", "htpasswd", "dovecot"
+)
 
 
 def load(configuration):

--- a/radicale/auth/dovecot.py
+++ b/radicale/auth/dovecot.py
@@ -1,0 +1,178 @@
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2014 Giel van Schijndel
+# Copyright © 2019 (GalaxyMaster)
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+import base64
+import itertools
+import os
+import socket
+from contextlib import closing
+
+from radicale import auth
+from radicale.log import logger
+
+
+class Auth(auth.BaseAuth):
+    def __init__(self, configuration):
+        super().__init__(configuration)
+        self.socket = configuration.get("auth", "dovecot_socket")
+        self.timeout = 5
+        self.request_id_gen = itertools.count(1)
+
+    def login(self, login, password):
+        """Validate credentials.
+
+        Check if the ``login``/``password`` pair is valid according to Dovecot.
+
+        This implementation communicates with a Dovecot server through the
+        Dovecot Authentication Protocol v1.1.
+
+        http://wiki2.dovecot.org/Design/AuthProtocol
+
+        """
+
+        logger.info("Authentication request (dovecot): '{}'".format(login))
+        if not login or not password:
+            return ""
+
+        with closing(socket.socket(
+                socket.AF_UNIX,
+                socket.SOCK_STREAM)
+        ) as sock:
+            try:
+                sock.settimeout(self.timeout)
+                sock.connect(self.socket)
+
+                buf = bytes()
+                supported_mechs = []
+                done = False
+                seen_part = [0, 0, 0]
+                # Upon the initial connection we only care about the
+                # handshake, which is usually just around 100 bytes long,
+                # e.g.
+                #
+                # VERSION	1	2
+                # MECH	PLAIN	plaintext
+                # SPID	22901
+                # CUID	1
+                # COOKIE	2dbe4116a30fb4b8a8719f4448420af7
+                # DONE
+                #
+                # Hence, we try to read just once with a buffer big
+                # enough to hold all of it.
+                buf = sock.recv(1024)
+                while b'\n' in buf and not done:
+                    line, buf = buf.split(b'\n', 1)
+                    parts = line.split(b'\t')
+                    first, parts = parts[0], parts[1:]
+
+                    if first == b'VERSION':
+                        if seen_part[0]:
+                            logger.warning(
+                                    "Server presented multiple VERSION "
+                                    "tokens, ignoring"
+                            )
+                            continue
+                        version = parts
+                        logger.debug("Dovecot server version: '{}'".format(
+                            (b'.'.join(version)).decode()
+                        ))
+                        if int(version[0]) != 1:
+                            logger.fatal(
+                                    "Only Dovecot 1.x versions are supported!"
+                            )
+                            return ""
+                        seen_part[0] += 1
+                    elif first == b'MECH':
+                        supported_mechs.append(parts[0])
+                        seen_part[1] += 1
+                    elif first == b'DONE':
+                        seen_part[2] += 1
+                        if not (seen_part[0] and seen_part[1]):
+                            logger.fatal(
+                                    "An unexpected end of the server "
+                                    "handshake received!"
+                            )
+                            return ""
+                        done = True
+
+                if not done:
+                    logger.fatal("Encountered a broken server handshake!")
+                    return ""
+
+                logger.debug(
+                        "Supported auth methods: '{}'"
+                        .format((b"', '".join(supported_mechs)).decode())
+                )
+                if b'PLAIN' not in supported_mechs:
+                    logger.info(
+                            "Authentication method 'PLAIN' is not supported, "
+                            "but is required!"
+                    )
+                    return ""
+
+                # Handshake
+                logger.debug("Sending auth handshake")
+                sock.send(b'VERSION\t1\t1\n')
+                sock.send(b'CPID\t%u\n' % os.getpid())
+
+                request_id = next(self.request_id_gen)
+                logger.debug(
+                        "Authenticating with request id: '{}'"
+                        .format(request_id)
+                )
+                sock.send(
+                        b'AUTH\t%u\tPLAIN\tservice=radicale\tresp=%b\n' %
+                        (
+                            request_id, base64.b64encode(
+                                    b'\0%b\0%b' %
+                                    (login.encode(), password.encode())
+                            )
+                        )
+                )
+
+                logger.debug("Processing auth response")
+                buf = sock.recv(1024)
+                line = buf.split(b'\n', 1)[0]
+                parts = line.split(b'\t')[:2]
+                resp, reply_id, params = (
+                        parts[0], int(parts[1]),
+                        dict(part.split('=', 1) for part in parts[2:])
+                )
+
+                logger.debug(
+                        "Auth response: result='{}', id='{}', parameters={}"
+                        .format(resp.decode(), reply_id, params)
+                )
+                if request_id != reply_id:
+                    logger.fatal(
+                            "Unexpected reply ID {} received (expected {})"
+                            .format(
+                                    reply_id, request_id
+                            )
+                    )
+                    return ""
+
+                if resp == b'OK':
+                    return login
+
+            except socket.error as e:
+                logger.fatal(
+                        "Failed to communicate with Dovecot socket %r: %s" %
+                        (self.socket, e)
+                )
+
+        return ""

--- a/radicale/auth/dovecot.py
+++ b/radicale/auth/dovecot.py
@@ -40,7 +40,7 @@ class Auth(auth.BaseAuth):
         This implementation communicates with a Dovecot server through the
         Dovecot Authentication Protocol v1.1.
 
-        http://wiki2.dovecot.org/Design/AuthProtocol
+        https://dovecot.org/doc/auth-protocol.txt
 
         """
 

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -132,6 +132,10 @@ INITIAL_CONFIG = OrderedDict([
             "value": "bcrypt",
             "help": "htpasswd encryption method",
             "type": str}),
+        ("dovecot_socket", {
+            "value": "/var/run/dovecot/auth-client",
+            "help": "dovecot auth socket",
+            "type": str}),
         ("realm", {
             "value": "Radicale - Password Required",
             "help": "message displayed when a password is needed",

--- a/radicale/tests/test_auth.py
+++ b/radicale/tests/test_auth.py
@@ -182,6 +182,9 @@ class TestBaseAuthRequests(BaseTest):
         if "mech" not in broken:
             handshake += b'MECH\t%b\n' % b' '.join(mech)
 
+        if "duplicate" in broken:
+            handshake += b'VERSION\t1\t2\n'
+
         if "done" not in broken:
             handshake += b'DONE\n'
 
@@ -214,6 +217,12 @@ class TestBaseAuthRequests(BaseTest):
     def test_dovecot_broken_handshake_incompatible(self):
         self._test_dovecot("user", "password", 401, broken=["incompatible"])
 
+    def test_dovecot_broken_handshake_duplicate(self):
+        self._test_dovecot(
+                "user", "password", 207, response=b'OK\t1',
+                broken=["duplicate"]
+        )
+
     def test_dovecot_broken_handshake_no_mech(self):
         self._test_dovecot("user", "password", 401, broken=["mech"])
 
@@ -226,8 +235,14 @@ class TestBaseAuthRequests(BaseTest):
     def test_dovecot_broken_socket(self):
         self._test_dovecot("user", "password", 401, broken=["socket"])
 
-    def test_dovecot_auth_good(self):
+    def test_dovecot_auth_good1(self):
         self._test_dovecot("user", "password", 207, response=b'OK\t1')
+
+    def test_dovecot_auth_good2(self):
+        self._test_dovecot(
+                "user", "password", 207, response=b'OK\t1',
+                mech=[b'PLAIN\nEXTRA\tTERM']
+        )
 
     def test_dovecot_auth_bad1(self):
         self._test_dovecot("user", "password", 401, response=b'FAIL\t1')
@@ -236,7 +251,7 @@ class TestBaseAuthRequests(BaseTest):
         self._test_dovecot("user", "password", 401, response=b'CONT\t1')
 
     def test_dovecot_auth_id_mismatch(self):
-        self._test_dovecot("user", "password", 401, response=b'CONT\t2')
+        self._test_dovecot("user", "password", 401, response=b'OK\t2')
 
     def test_custom(self):
         """Custom authentication."""


### PR DESCRIPTION
This work is heavily based on prior art by Giel van Schijndel (#200),
however the code was made Python 3 compatible, error checking
has been improved, and tests were introduced:

```
$ python setup.py test --extras --addopts "-k auth"
[skipped]
Name                        Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------
radicale/auth/dovecot.py       76      2     26      2    96%
[skipped]
=== 34 passed, 16 skipped, 198 deselected in 2.35 seconds ===
```