### PR TITLE
Added support for LDAP authentication

### DIFF
--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -58,7 +58,8 @@ from importlib import import_module
 
 from radicale.log import logger
 
-INTERNAL_TYPES = ("none", "remote_user", "http_x_remote_user", "htpasswd")
+INTERNAL_TYPES = ("none", "remote_user", "http_x_remote_user", "htpasswd",
+                  "ldap")
 
 
 def load(configuration):

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -1,0 +1,82 @@
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2008 Nicolas Kandel
+# Copyright © 2008 Pascal Halter
+# Copyright © 2008-2017 Guillaume Ayoub
+# Copyright © 2017-2018 Unrud<unrud@outlook.com>
+# Copyright © 2019 Marco Fleckinger<marco.fleckinger@gmail.com>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from radicale import auth
+
+
+class Auth(auth.BaseAuth):
+    def __init__(self, configuration):
+        super().__init__(configuration)
+
+        try:
+            import ldap3
+        except ImportError as e:
+            raise RuntimeError(
+               "LDAP authentication requires the ldap3 module") from e
+
+        self.ldap3 = ldap3
+        self.server_uri = configuration.get("auth", "ldap_server_uri")
+        self.bind_dn_pattern = configuration.get("auth", "ldap_bind_dn")
+
+    def login(self, login, password):
+        """
+            Validate credentials.
+            Simply try to sign in into ldap server with given
+            credentials using dn from configuration
+        """
+
+        def substitute(match_object):
+            """
+                substitutes:
+                 * %d by the domain part
+                 * %n by the local part
+                 * %u by the whole given user name
+            """
+            patterns = {
+                'd': '.+?@(.+)',
+                'n': '(.+?)@.+',
+                'u': '(.+)'
+            }
+            key = match_object.group(1)
+            if key not in patterns:
+                raise RuntimeError("'%s' is an unknown variable" % key)
+            pattern = patterns[key]
+            m = re.match(pattern, login)
+            if m is None:
+                return ''
+            return m.group(1)
+
+        # First get the distinguished name to connect with to the server
+        bind_dn = re.sub('%([a-z])', substitute, self.bind_dn_pattern)
+        # Try to connect to the LDAP server by using
+        #   * the distinguished name
+        #   * the given password
+        try:
+            server = self.ldap3.Server(self.server_uri)
+            conn = self.ldap3.Connection(server, bind_dn, password=password)
+            if conn.bind():
+                return login
+        except self.ldap3.core.exceptions.LDAPSocketOpenError:
+            raise RuntimeError("unable to reach ldap server")
+        except Exception:
+            pass
+        return ""

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -132,6 +132,17 @@ INITIAL_CONFIG = OrderedDict([
             "value": "bcrypt",
             "help": "htpasswd encryption method",
             "type": str}),
+        ("ldap_server_uri", {
+            "value": "ldap://127.0.0.1",
+            "help": "URI of LDAP server",
+            "type": str}),
+        ("ldap_bind_dn", {
+            "value": "uid=%%n,ou=People,o=organization,dc=example,dc=com",
+            "help": "Distinguished Name to bind with, "
+                    "'%%n' is used for whole user name, "
+                    "'%%d' for domain part and "
+                    "'%%u' for local part of the username",
+            "type": str}),
         ("realm", {
             "value": "Radicale - Password Required",
             "help": "message displayed when a password is needed",

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     setup_requires=pytest_runner,
     tests_require=tests_require,
     extras_require={
+        "ldap3": "ldap3",
         "test": tests_require,
         "md5": "passlib",
         "bcrypt": "passlib[bcrypt]"},


### PR DESCRIPTION
Provides `auth` `type` `ldap` by auth binding. This requires installation of `ldap3` module. Feature can be configured by these two additional parameters:
* `ldap_server_uri`
* `ldap_bind_dn`

ldap_server_uri can be used as usual. it will directly be used for creating an ldap3 server object. For configuring ldap_bind_dn variables may be used. Those will be replaced by (parts) of the given login name. Variables start with double per cent sign `%%` and follow the doc from dovecot where:
 * `%%d` will be replaced by domain part of login name
 * `%%n` will be replaced by local part of login name
 * `%%u` will be replaced by whole login name

A sample configuration of LDAP authentication for radicale may be:

    [auth]
    type = ldap
    ldap_server_uri = ldaps://example.com:636
    ldap_bind_dn = uid=%%u,dc=example,dc=com

With this a user can login with a username like `username`. When a user should be able to login with `user@example.com` use this `ldap_bind_dn` configuration line:

    ldap_bind_dn = uid=%%n,dc=example,dc=com

This only uses the local part of the given login.