### PR TITLE
Fix export on leaf collections

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -80,8 +80,9 @@ def export_storage(config, path, debug=False):
                         traceback.print_exc()
                     continue
                 try:
-                    remaining_collections.extend(collection.children(
-                        collection.path))
+                    if collection.is_node(collection.path):
+                        remaining_collections.extend(collection.children(
+                            collection.path))
                 except Exception as e:
                     print("ERROR: Failed to find child collections of %r: %s" %
                           ("/" + collection.path, e))


### PR DESCRIPTION
When exporting from 1.1.6 to 2.0.0, I had this error:
 ```
ERROR: Failed to find child collections of '/': generator raised StopIteration
```
Adding a check on is_node/is_leaf fixed that.

This may fix the same or similar export errors seen in  #711 and #929