### PR TITLE
Enable passing custom args to __main__.run()

### DIFF
--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -32,7 +32,7 @@ from radicale import VERSION, config, log, server, storage
 from radicale.log import logger
 
 
-def run():
+def run(passed_args=None):
     """Run Radicale as a standalone server."""
     log.setup()
 
@@ -83,7 +83,7 @@ def run():
                 del kwargs["type"]
                 group.add_argument(*args, **kwargs)
 
-    args = parser.parse_args()
+    args = parser.parse_args(passed_args)
 
     # Preliminary configure logging
     if args.debug:


### PR DESCRIPTION
This is very useful when creating Radicale wrappers that want to change
some default values (such as storage modules) or want to filter out parameters.
Such example is https://github.com/etesync/etesync-dav