### PR TITLE
Add 'env' auth module

### DIFF
--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -58,7 +58,8 @@ from importlib import import_module
 
 from radicale.log import logger
 
-INTERNAL_TYPES = ("none", "remote_user", "http_x_remote_user", "htpasswd")
+INTERNAL_TYPES = ("none", "remote_user", "http_x_remote_user",
+                  "htpasswd", "env")
 
 
 def load(configuration):

--- a/radicale/auth/env.py
+++ b/radicale/auth/env.py
@@ -1,0 +1,36 @@
+# This file is part of Radicale Server - Calendar Server
+# Copyright © 2008 Nicolas Kandel
+# Copyright © 2008 Pascal Halter
+# Copyright © 2008-2017 Guillaume Ayoub
+# Copyright © 2017-2019 Unrud <unrud@outlook.com>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from radicale import auth
+
+
+class Auth(auth.BaseAuth):
+    def login(self, login, password):
+        env_login = os.environ.get('RADICALE_LOGIN')
+        env_password = os.environ.get('RADICALE_PASSWORD')
+
+        if env_login is None or env_password is None:
+            return ""
+
+        if login == env_login and password == env_password:
+            return login
+
+        return ""


### PR DESCRIPTION
I wrote a small authentication module, which takes login and password from environment variables.

**Use-case**: This makes it really easy to setup a single-user-Radicale-instance in a dockerized environment.

Config:
```
[server]
# Bind all addresses
hosts = 0.0.0.0:5232

[auth]
type = env
```

A docker-compose.yml could look like this:

```
services:
  radicale:
    build: .
    ports:
      - 5232:5232
    volumes:
      - ./radicale:/data
      - ./radicale_config:/etc/radicale/
    environment:
      RADICALE_LOGIN: admin
      RADICALE_PASSWORD: test123
```