### PR TITLE
Add $http_host Host header to nginx documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -334,6 +334,7 @@ location /radicale/ { # The trailing / is important!
     proxy_pass        http://localhost:5232/; # The / is important!
     proxy_set_header  X-Script-Name /radicale;
     proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
     proxy_pass_header Authorization;
 }
 ```
@@ -370,6 +371,7 @@ location /radicale/ {
     proxy_set_header     X-Script-Name /radicale;
     proxy_set_header     X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header     X-Remote-User $remote_user;
+    proxy_set_header     Host $http_host;
     auth_basic           "Radicale - Password Required";
     auth_basic_user_file /etc/nginx/htpasswd;
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -334,7 +334,7 @@ location /radicale/ { # The trailing / is important!
     proxy_pass        http://localhost:5232/; # The / is important!
     proxy_set_header  X-Script-Name /radicale;
     proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
+    proxy_set_header  Host $http_host;
     proxy_pass_header Authorization;
 }
 ```


### PR DESCRIPTION
This seems to cause issues with macOS Calendar, see
for example issue #842, where a 502 error is raised.

In my case, this was happening because of the
`HTTP_HOST` header being set to `localhost:PORT`
while my radicale was configured to be at some
`domain.tld` address.

I've tried it with the current `master` branch and
this seems to solve the issue with macOS Calendar not
being able to move the events from one calendar to
another.