### PR TITLE
Fixing Dockerfile (pip3 and bcrypt)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apk add --no-cache \
       libffi-dev \
       ca-certificates \
       openssl
+# Install pip3
+RUN apk add cmd:pip3
 # Install Radicale
 RUN wget --quiet https://github.com/Kozea/Radicale/archive/${VERSION}.tar.gz --output-document=radicale.tar.gz && \
     tar xzf radicale.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apk add --no-cache \
       openssl
 # Install pip3
 RUN apk add cmd:pip3
+# Install bcrypt (for authentication)
+RUN pip3 install py-bcrypt
 # Install Radicale
 RUN wget --quiet https://github.com/Kozea/Radicale/archive/${VERSION}.tar.gz --output-document=radicale.tar.gz && \
     tar xzf radicale.tar.gz && \


### PR DESCRIPTION
The `Dockerfile` that ships with the project was broken, and did not install `pip3` or `bcrypt`. This PR installs `pip3` command using whatever package may be necessary (to prevent future breakage), and also installs `bcrypt` to allow secure authentication.