### PR TITLE
better dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,18 @@
-FROM alpine:latest
+FROM python:alpine
 
 # Version of Radicale (e.g. 3.0.x)
 ARG VERSION=master
 
+WORKDIR /radicale
+
+COPY . .
+
 # Install dependencies
-RUN apk add --no-cache \
-      python3 \
-      py3-pip \
-      python3-dev \
-      build-base \
-      libffi-dev \
-      ca-certificates \
-      openssl
-# Install Radicale
-RUN wget --quiet https://github.com/Kozea/Radicale/archive/${VERSION}.tar.gz --output-document=radicale.tar.gz && \
-    tar xzf radicale.tar.gz && \
-    pip3 install ./Radicale-${VERSION}[bcrypt] && \
-    rm -r radicale.tar.gz Radicale-${VERSION}
-# Remove build dependencies
-RUN apk del \
-      python3-dev \
-      build-base \
-      libffi-dev
+RUN apk add --no-cache gcc musl-dev libffi-dev ca-certificates openssl && \
+    # Install Radicale
+    pip3 install --no-cache .[bcrypt] && \
+    # Remove build dependencies
+    apk del gcc musl-dev libffi-dev
 # Persistent storage for data (Mount it somewhere on the host!)
 VOLUME /var/lib/radicale
 # Configuration data (Put the "config" file here!)


### PR DESCRIPTION
* uses python-alpine rather than downloading python from APK repos
* uses a workdir (good practice)
* use local git checkout that is supposed to exist (that Dockerfile is in the git repo)
* install less deps
* merge install steps so it doesn't create separate big layers

Image size went from 329MB to 101MB, and on my machine, build time without cache went from 75 seconds to 45 minutes.

I was able to run the tests successfully from within the docker images and I was able to display the login page, so I think it works as good as before.