### PR TITLE
Adds config value to serve from subdirectory

### DIFF
--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -211,6 +211,8 @@ class Application(
             unsafe_base_prefix = environ["HTTP_X_SCRIPT_NAME"]
             logger.debug("Script name overwritten by client: %r",
                          unsafe_base_prefix)
+        elif self.configuration.get("server", "subdirectory"):
+            unsafe_base_prefix = self.configuration.get("server", "subdirectory")
         else:
             # SCRIPT_NAME is already removed from PATH_INFO, according to the
             # WSGI specification.

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -140,6 +140,11 @@ DEFAULT_CONFIG_SCHEMA = OrderedDict([
             "help": "set CA certificate for validating clients",
             "aliases": ["--certificate-authority"],
             "type": filepath}),
+        ("subdirectory", {
+            "value": "",
+            "help": "set subdirectory",
+            "aliases": ["--subdirectory"],
+            "type": filepath}),
         ("_internal_server", {
             "value": "False",
             "help": "the internal server is used",


### PR DESCRIPTION
This adds the possibility to serve radicale from a subdirectory, by specifying the subdirectory in the radicale config file.

I have the feeling, that the functionality to serve radicale from a subdirectory is implemented already, but somehow I couldn't find anything about it in the documentation and wasn't able to figure out how it is done.