### PR TITLE
ensure group 'radicale' gets created

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -213,7 +213,7 @@ requirements.
 ### Linux with systemd system-wide
 
 Create the **radicale** user and group for the Radicale service.
-(Run `useradd --system --home-dir / --shell /sbin/nologin radicale` as root.)
+(Run `useradd --system --user-group --home-dir / --shell /sbin/nologin radicale` as root.)
 The storage folder must be writable by **radicale**. (Run
 `mkdir -p /var/lib/radicale/collections && chown -R radicale:radicale /var/lib/radicale/collections`
 as root.)


### PR DESCRIPTION
Without the option --user-group the creation of the group depends on default values.
In OpenSUSE Tumbleweed the user 'radicale' became a member of 'users'.

This fixes #1101 