### PR TITLE
Failed login attempts enhanchment

### DIFF
--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -230,7 +230,7 @@ class Application(
         elif user:
             logger.info("Successful login: %r -> %r", login, user)
         elif login:
-            logger.info("Failed login attempt: %r", login)
+            logger.warning("Failed login attempt from %s: %r", remote_host, login)
             # Random delay to avoid timing oracles and bruteforce attacks
             delay = self.configuration.get("auth", "delay")
             if delay > 0:


### PR DESCRIPTION
Radicale now prints remote host IP address next to the failed login attempt, and uses [Warning] log level.

This makes the log easily parseable by fail2ban and allows to reduce the log verbosity.
Requested by #918 and #987 