### PR TITLE
docs: fix simple typo, errornous -> erroneous

### DIFF
--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -195,7 +195,7 @@ class BaseCollection:
             # Concatenate all child elements of VCALENDAR from all items
             # together, while preventing duplicated VTIMEZONE entries.
             # VTIMEZONEs are only distinguished by their TZID, if different
-            # timezones share the same TZID this produces errornous ouput.
+            # timezones share the same TZID this produces erroneous ouput.
             # VObject fails at this too.
             for item in self.get_all():
                 depth = 0

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -195,7 +195,7 @@ class BaseCollection:
             # Concatenate all child elements of VCALENDAR from all items
             # together, while preventing duplicated VTIMEZONE entries.
             # VTIMEZONEs are only distinguished by their TZID, if different
-            # timezones share the same TZID this produces erroneous ouput.
+            # timezones share the same TZID this produces erroneous output.
             # VObject fails at this too.
             for item in self.get_all():
                 depth = 0


### PR DESCRIPTION
There is a small typo in radicale/storage/__init__.py.

Should read `erroneous` rather than `errornous`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md