### PR TITLE
Encode password to allow special characters

### DIFF
--- a/radicale/web/internal_data/fn.js
+++ b/radicale/web/internal_data/fn.js
@@ -120,7 +120,7 @@ function Collection(href, type, displayname, description, color) {
  */
 function get_principal(user, password, callback) {
     let request = new XMLHttpRequest();
-    request.open("PROPFIND", SERVER + ROOT_PATH, true, user, password);
+    request.open("PROPFIND", SERVER + ROOT_PATH, true, user, encodeURIComponent(password));
     request.onreadystatechange = function() {
         if (request.readyState !== 4) {
             return;
@@ -163,7 +163,7 @@ function get_principal(user, password, callback) {
  */
 function get_collections(user, password, collection, callback) {
     let request = new XMLHttpRequest();
-    request.open("PROPFIND", SERVER + collection.href, true, user, password);
+    request.open("PROPFIND", SERVER + collection.href, true, user, encodeURIComponent(password));
     request.setRequestHeader("depth", "1");
     request.onreadystatechange = function() {
         if (request.readyState !== 4) {
@@ -264,7 +264,7 @@ function get_collections(user, password, collection, callback) {
  */
 function upload_collection(user, password, collection_href, file, callback) {
     let request = new XMLHttpRequest();
-    request.open("PUT", SERVER + collection_href, true, user, password);
+    request.open("PUT", SERVER + collection_href, true, user, encodeURIComponent(password));
     request.onreadystatechange = function() {
         if (request.readyState !== 4) {
             return;
@@ -289,7 +289,7 @@ function upload_collection(user, password, collection_href, file, callback) {
  */
 function delete_collection(user, password, collection, callback) {
     let request = new XMLHttpRequest();
-    request.open("DELETE", SERVER + collection.href, true, user, password);
+    request.open("DELETE", SERVER + collection.href, true, user, encodeURIComponent(password));
     request.onreadystatechange = function() {
         if (request.readyState !== 4) {
             return;
@@ -314,7 +314,7 @@ function delete_collection(user, password, collection, callback) {
  */
 function create_edit_collection(user, password, collection, create, callback) {
     let request = new XMLHttpRequest();
-    request.open(create ? "MKCOL" : "PROPPATCH", SERVER + collection.href, true, user, password);
+    request.open(create ? "MKCOL" : "PROPPATCH", SERVER + collection.href, true, user, encodeURIComponent(password));
     request.onreadystatechange = function() {
         if (request.readyState !== 4) {
             return;


### PR DESCRIPTION
XMLHttpRequest.open() does not automatically encode the password. Though it builds an basic auth schemed URI where '%' is the escaping indicator, thus passwords containing this characters are not accepted this way without manually replacing '%' with '%25' on the form.