### PR TITLE
Fix is-not-defined filter in addressbook-query report

### DIFF
--- a/radicale/item/filter.py
+++ b/radicale/item/filter.py
@@ -115,7 +115,7 @@ def prop_match(vobject_item, filter_, ns):
         # Point #1 of rfc4791-9.7.2
         return name in vobject_item.contents
     if len(filter_) == 1:
-        if filter_[0].tag == xmlutils.make_clark("C:is-not-defined"):
+        if filter_[0].tag == xmlutils.make_clark("%s:is-not-defined" % ns):
             # Point #2 of rfc4791-9.7.2
             return name not in vobject_item.contents
     if name not in vobject_item.contents:


### PR DESCRIPTION
The XML namespace it not properly set for CardDAV when a prop-filter that contains an `is-not-defined` child evaluated in the context of a CardDAV addressbook-query report. Therefore, radicale rejects such reports with a bad request error.

Example request:

```xml
<?xml version="1.0"?>
<CARDDAV:addressbook-query xmlns:DAV="DAV:" xmlns:CARDDAV="urn:ietf:params:xml:ns:carddav" xmlns:CS="http://calendarserver.org/ns/">
 <DAV:prop>
  <DAV:getetag/>
  <CARDDAV:address-data/>
 </DAV:prop>
 <CARDDAV:filter test="anyof">
  <CARDDAV:prop-filter name="IMPP" test="anyof">
   <CARDDAV:is-not-defined/>
  </CARDDAV:prop-filter>
 </CARDDAV:filter>
</CARDDAV:addressbook-query>
```

Reply:

```
HTTP/1.0 400 Bad Request
Date: Fri, 22 Jan 2021 14:22:16 GMT
Server: WSGIServer/0.2 CPython/3.8.5
Content-Type: text/plain; charset=utf-8
Content-Length: 11

Bad Request
```