### PR TITLE
Log to syslog, too.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1104,9 +1104,11 @@ Delete collections by deleting the corresponding folders.
 
 ## Logging
 
-Radicale logs to `stderr`. The verbosity of the log output can be controlled
-with `--debug` command line argument or the `level` configuration option in
-the `logging` section.
+Radicale logs to `stderr` and syslog's `daemon` facility.
+
+The verbosity of the log output can be controlled with `--debug` or `--logging-level`
+command line arguments or the `level` configuration option in
+the `logging` section. By default logging is silenced.
 
 ## Architecture
 

--- a/radicale/log.py
+++ b/radicale/log.py
@@ -114,6 +114,8 @@ def setup() -> None:
     handler = ThreadedStreamHandler()
     logging.basicConfig(format=LOGGER_FORMAT, datefmt=DATE_FORMAT,
                         handlers=[handler])
+    logger.addHandler(logging.handlers.SysLogHandler(address='/dev/log',
+                                                     facility=logging.handlers.SysLogHandler.LOG_DAEMON))
     register_stream = handler.register_stream
     log_record_factory = IdentLogRecordFactory(logging.getLogRecordFactory())
     logging.setLogRecordFactory(log_record_factory)

--- a/radicale/log.py
+++ b/radicale/log.py
@@ -25,7 +25,7 @@ Log messages are sent to the first available target of:
 
 """
 
-import logging
+import logging, logging.handlers
 import os
 import sys
 import threading


### PR DESCRIPTION
Hiya! :tulip: 

I read your docs and I [saw](https://radicale.org/3.0.html#documentation/logging)

> Radicale logs to `stderr`.

I like the [12 factor app](https://12factor.net/) too, but unfortunately BSD has no way built to capture stderr logs: it expects programs to use syslog. I set up this [start script](https://man.openbsd.org/rc.d)

<details><summary>/etc/rc.d/radicale</summary>

```
#!/bin/ksh

daemon="/usr/local/bin/radicale"
daemon_user="_radicale"

. /etc/rc.d/rc.subr

rc_start() {
        ${rcexec} "${daemon} ${daemon_flags} &"
}

pexp="/usr/local/bin/python3.8 /usr/local/bin/radicale"

rc_cmd $1
```

</details>

and with that `rcctl start radicale` works, but it loses the logs, which made debugging my deployment difficult.

I noticed that, though undocumented, you respect WSGI redirecting logs:

https://github.com/Kozea/Radicale/blob/f72b3449818600962268bc96a2a12e8e022a0c42/radicale/log.py#L21-L24

so I thought maybe you'd be open to syslog as well? What do you think?