### PR TITLE
config & rights: use open() for better error messages

### DIFF
--- a/radicale/rights/from_file.py
+++ b/radicale/rights/from_file.py
@@ -56,8 +56,8 @@ class Rights(rights.BaseRights):
         escaped_user = re.escape(user)
         rights_config = configparser.ConfigParser()
         try:
-            if not rights_config.read(self._filename):
-                raise RuntimeError("No such file: %r" % self._filename)
+            with open(self._filename, "r") as f:
+                rights_config.read_file(f)
         except Exception as e:
             raise RuntimeError("Failed to load rights file %r: %s" %
                                (self._filename, e)) from e


### PR DESCRIPTION
ConfigParser().read() doesn't differentiate between different types of
failure to read files, causing eg. "No such file" to be logged in all
cases, for example if permissions are insufficient. fix that by using
open() and ConfigParser().read_file() instead.