### PR TITLE
Added support for webcal-subscriptions

### DIFF
--- a/radicale/app/propfind.py
+++ b/radicale/app/propfind.py
@@ -85,7 +85,7 @@ def xml_propfind_response(
 
     if isinstance(item, storage.BaseCollection):
         is_collection = True
-        is_leaf = item.tag in ("VADDRESSBOOK", "VCALENDAR")
+        is_leaf = item.tag in ("VADDRESSBOOK", "VCALENDAR", "VSUBSCRIBED")
         collection = item
         # Some clients expect collections to end with `/`
         uri = pathutils.unstrip_path(item.path, True)
@@ -259,6 +259,10 @@ def xml_propfind_response(
                         child_element = ET.Element(
                             xmlutils.make_clark("C:calendar"))
                         element.append(child_element)
+                    elif collection.tag == "VSUBSCRIBED":
+                        child_element = ET.Element(
+                            xmlutils.make_clark("CS:subscribed"))
+                        element.append(child_element)
                 child_element = ET.Element(xmlutils.make_clark("D:collection"))
                 element.append(child_element)
             elif tag == xmlutils.make_clark("RADICALE:displayname"):
@@ -284,6 +288,13 @@ def xml_propfind_response(
             elif tag == xmlutils.make_clark("D:sync-token"):
                 if is_leaf:
                     element.text, _ = collection.sync()
+                else:
+                    is404 = True
+            elif tag == xmlutils.make_clark("CS:source"):
+                if is_leaf:
+                    child_element = ET.Element(xmlutils.make_clark("D:href"))
+                    child_element.text = collection.get_meta('CS:source')
+                    element.append(child_element)
                 else:
                     is404 = True
             else:

--- a/radicale/item/__init__.py
+++ b/radicale/item/__init__.py
@@ -91,7 +91,7 @@ def check_and_sanitize_items(
     The ``tag`` of the collection.
 
     """
-    if tag and tag not in ("VCALENDAR", "VADDRESSBOOK"):
+    if tag and tag not in ("VCALENDAR", "VADDRESSBOOK", "VSUBSCRIBED"):
         raise ValueError("Unsupported collection tag: %r" % tag)
     if not is_collection and len(vobject_items) != 1:
         raise ValueError("Item contains %d components" % len(vobject_items))
@@ -230,7 +230,7 @@ def check_and_sanitize_props(props: MutableMapping[Any, Any]
             raise ValueError("Value of %r must be %r not %r: %r" % (
                 k, str.__name__, type(v).__name__, v))
         if k == "tag":
-            if v not in ("", "VCALENDAR", "VADDRESSBOOK"):
+            if v not in ("", "VCALENDAR", "VADDRESSBOOK", "VSUBSCRIBED"):
                 raise ValueError("Unsupported collection tag: %r" % v)
     return props
 

--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -33,7 +33,8 @@ from radicale import item, pathutils
 
 MIMETYPES: Mapping[str, str] = {
     "VADDRESSBOOK": "text/vcard",
-    "VCALENDAR": "text/calendar"}
+    "VCALENDAR": "text/calendar",
+    "VSUBSCRIBED": "text/calendar"}
 
 OBJECT_MIMETYPES: Mapping[str, str] = {
     "VCARD": "text/vcard",


### PR DESCRIPTION
This PR adds support for webcal subscriptions, as discussed in #776.

Please note, that this is a backend-focused implementation, so efforts to adapt the web UI have not been made in this changeset.

Webcal subscriptions can be added in the form of a collection, just like calendars, todo lists and the like. The URL to the targeted online ICS file, as well as the display name and an optional color for the calendar are stored in the `.Radicale.props` file of the regarding collection.

Steps to subscribe to a calendar manually:

1. Create a new collection (folder) in Radicale's `collection-root/` directory
2. Create a `.Radicale.props` file, structured as shown in the example below

The subscribed calendar will now be advertised by Radicale and should appear in supported applications (e.g. [DAVx⁵](https://f-droid.org/de/packages/at.bitfire.davdroid/) for Android)

Example:

```jsonc
// cat collection-root/[...]/[a collection]/.Radicale.props
{
    "tag": "VSUBSCRIBED",
    "D:displayname": "Online Calendar",
    "ICAL:calendar-color": "#00BBEEFF",
    "CS:source": "https://example.org/online-calendar.ics"
}
```

Result (DAVx⁵ + ICSx⁵):

<img alt="Screenshot_20220328-191826232" src="https://user-images.githubusercontent.com/7886606/160452919-6d5c5226-4356-4a1b-99e9-bf782a091d2d.jpg" width="40%" /> <img alt="Screenshot_20220328-191846410" src="https://user-images.githubusercontent.com/7886606/160452965-f97b7867-df36-4e07-bbf2-62a703a0d49d.jpg" width="40%" />