### PR TITLE
Drop timestamp and PID from log format.

### DIFF
--- a/radicale/log.py
+++ b/radicale/log.py
@@ -34,8 +34,7 @@ from typing import Any, Callable, ClassVar, Dict, Iterator, Union
 from radicale import types
 
 LOGGER_NAME: str = "radicale"
-LOGGER_FORMAT: str = "[%(asctime)s] [%(ident)s] [%(levelname)s] %(message)s"
-DATE_FORMAT: str = "%Y-%m-%d %H:%M:%S %z"
+LOGGER_FORMAT: str = "[%(levelname)s] %(message)s"
 
 logger: logging.Logger = logging.getLogger(LOGGER_NAME)
 
@@ -112,8 +111,7 @@ def setup() -> None:
     """Set global logging up."""
     global register_stream
     handler = ThreadedStreamHandler()
-    logging.basicConfig(format=LOGGER_FORMAT, datefmt=DATE_FORMAT,
-                        handlers=[handler])
+    logging.basicConfig(format=LOGGER_FORMAT, handlers=[handler])
     register_stream = handler.register_stream
     log_record_factory = IdentLogRecordFactory(logging.getLogRecordFactory())
     logging.setLogRecordFactory(log_record_factory)


### PR DESCRIPTION
Radicale is designed to be run under a service manager of some kind, primarily systemd but also OpenBSD's rcctl, docker, kubernetes, etc. All of these log timestamps and some ID for the sending process.

Even on non-systemd systems, it's easy route the logs to syslog, with timestamp and PID attached using

    radicale 2>&1 | logger -ip daemon.info -t radicale

see: https://github.com/Kozea/Radicale/issues/1085/#issuecomment-1104532326

Basically, this is redundant:

```
[kousu@radio ~]$ sudo journalctl -f -u radicale
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] Loaded config file '/etc/radicale/config'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] Skipped missing config file '/.config/radicale/config'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] Starting Radicale
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] auth type is 'radicale.auth.none'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] storage type is 'radicale.storage.multifilesystem'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] rights type is 'radicale.rights.owner_only'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] web type is 'radicale.web.internal'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] Listening on '[127.0.0.1]:5232'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] Listening on '[::1]:5232'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [2022-04-20 16:48:46 -0400] [17569] [INFO] Radicale server ready
```

so this makes the output instead:

```
[kousu@radio ~]$ sudo journalctl -f -u radicale
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] Loaded config file '/etc/radicale/config'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] Skipped missing config file '/.config/radicale/config'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] Starting Radicale
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] auth type is 'radicale.auth.none'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] storage type is 'radicale.storage.multifilesystem'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] rights type is 'radicale.rights.owner_only'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] web type is 'radicale.web.internal'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] Listening on '[127.0.0.1]:5232'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] Listening on '[::1]:5232'
Apr 20 16:48:46 radio.kousu.ca radicale[17569]: [INFO] Radicale server ready
```