### PR TITLE
Fix docs: default value of `htpasswd_filename`

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -673,7 +673,7 @@ Default: `none`
 
 Path to the htpasswd file.
 
-Default:
+Default: `/etc/radicale/users`
 
 ##### htpasswd_encryption
 


### PR DESCRIPTION
Fix mismatch between default values of `htpasswd_filename` in `config.py` and `DOCUMENTATION.md`:

https://github.com/Kozea/Radicale/blob/c14defcba87b7fb83e0556f1000706cdd21b230e/radicale/config.py#L165-L168

