### PR TITLE
Listen on IPv4 and IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ VOLUME /var/lib/radicale
 EXPOSE 5232
 # Run Radicale
 ENTRYPOINT [ "/app/bin/python", "/app/bin/radicale"]
-CMD ["--hosts", "0.0.0.0:5232"]
+CMD ["--hosts", "0.0.0.0:5232,[::]:5232"]
 
 USER radicale


### PR DESCRIPTION
Dockerfile currently only listens on IPv4. This change makes it listen on IPv6 also.

Fixes #1138