### PR TITLE
MOVE: consider HTTP_X_FORWARDED_HOST also supported in case Radicale is running behind reverse proxy

### DIFF
--- a/radicale/app/move.py
+++ b/radicale/app/move.py
@@ -33,10 +33,16 @@ class ApplicationPartMove(ApplicationBase):
         """Manage MOVE request."""
         raw_dest = environ.get("HTTP_DESTINATION", "")
         to_url = urlparse(raw_dest)
-        if to_url.netloc != environ["HTTP_HOST"]:
-            logger.info("Unsupported destination address: %r", raw_dest)
-            # Remote destination server, not supported
-            return httputils.REMOTE_DESTINATION
+        if environ.get("HTTP_X_FORWARDED_HOST"):
+            if to_url.netloc != environ["HTTP_X_FORWARDED_HOST"]:
+                logger.info("Unsupported destination address: %r", raw_dest)
+                # Remote destination server, not supported
+                return httputils.REMOTE_DESTINATION
+        else:
+            if to_url.netloc != environ["HTTP_HOST"]:
+                logger.info("Unsupported destination address: %r", raw_dest)
+                # Remote destination server, not supported
+                return httputils.REMOTE_DESTINATION
         access = Access(self._rights, user, path)
         if not access.check("w"):
             return httputils.NOT_ALLOWED


### PR DESCRIPTION
While `thunderbird` uses DELETE -> PUT sequence for moving a calendar item from one calendar to the other, iOS uses MOVE, which causing an issue in case of Radicale is running behind a reverse proxy.

Upstream version < 2022-11-20:

```
[1128/Thread-10331] [INFO] MOVE request for '/USER1/GROUP1.ics/UUID.ics' received from 127.0.0.1 (forwarded for 'CLIENT-IP') using 'iOS/16.1.1 (20B101) dataaccessd/1.0'
```

Move is rejected with "502"

```
[1128/Thread-10331] [INFO] Unsupported destination address: 'https://SERVER-FQDN/USER1/USER1.ics/UUID.ics'
[1128/Thread-10331] [INFO] MOVE response status for '/USER1/GROUP1.ics/UUID.ics' in 0.004 seconds: 502 Bad Gateway
```

This PR compares the host part of the given destination against the `X-Forwarded-Host` header if provided.

Once applied, MOVE is successful:

```
MOVE response status for '/USER1/USER1.ics/UUID.ics' in 0.373 seconds: 201 Created
```