### PR TITLE
changed rel="shortcut icon" to rel="icon"

### DIFF
--- a/radicale/web/internal_data/index.html
+++ b/radicale/web/internal_data/index.html
@@ -7,7 +7,7 @@
 <script src="fn.js"></script>
 <title>Radicale Web Interface</title>
 <link href="css/main.css" media="screen" rel="stylesheet">
-<link href="css/icon.png" type="image/png" rel="shortcut icon">
+<link href="css/icon.png" type="image/png" rel="icon">
 <style>
     .hidden {display:none;}
 </style>


### PR DESCRIPTION
"icon" is standard and used by all modern browsers. Only IE needed "shortcut icon". Since is it not longer supported and would have needed an .ico-file, "icon" is the right value for rel.