### PR TITLE
Explain possible pitfall when using git with systemd

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -528,6 +528,16 @@ git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s)
 The command gets executed after every change to the storage and commits
 the changes into the **git** repository.
 
+For the hook to not cause errors either **git** user details need to be set and match the owner of the collections directory or the repository needs to be marked as safe.
+
+When using the systemd unit file from the [Running as a service](#running-as-a-service) section this **cannot** be done via a `.gitconfig` file in the users home directory, as Radicale won't have read permissions!
+
+In `/var/lib/radicale/collections` run:
+```bash
+git config user.name "radicale"
+git config user.email "radicale@example.com"
+```
+
 ## Documentation
 
 ### Configuration

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -532,7 +532,7 @@ For the hook to not cause errors either **git** user details need to be set and 
 
 When using the systemd unit file from the [Running as a service](#running-as-a-service) section this **cannot** be done via a `.gitconfig` file in the users home directory, as Radicale won't have read permissions!
 
-In `/var/lib/radicale/collections` run:
+In `/var/lib/radicale/collections/.git` run:
 ```bash
 git config user.name "radicale"
 git config user.email "radicale@example.com"


### PR DESCRIPTION
When setting up Radicale I had some headache getting git to run. Radicale gave me internal server errors.
The logs showed, that the default git hook was to blame.

git complains about the repository being unsafe with an 128 error code, which results in Radicale being unable to complete requests.

As I didn't want to just disable the owner safety check for this repository I created a .gitconfig to set user name and email.
Turns out the unit file suggested by the documentation does not allow read access to the users home directory, which means this won't actually solve anything.

I feel the Tutorial should mention this (and how to properly set up git) as otherwise the combination of those setup snippets will not result in a viable configuration.