### PR TITLE
Add custom Radicale DAV property getcontentcount

### DIFF
--- a/radicale/app/propfind.py
+++ b/radicale/app/propfind.py
@@ -272,6 +272,12 @@ def xml_propfind_response(
                     element.text = displayname
                 else:
                     is404 = True
+            elif tag == xmlutils.make_clark("RADICALE:getcontentcount"):
+                # Only for internal use by the web interface
+                if is_collection or is_leaf:
+                    element.text = str(sum(1 for entry in item.get_all()))
+                else:
+                    is404 = True
             elif tag == xmlutils.make_clark("D:displayname"):
                 displayname = collection.get_meta("D:displayname")
                 if not displayname and is_leaf:


### PR DESCRIPTION
This adds a custom Radicale DAV property called 'getcontentcount' which returns the number of entries contained within that collection.