### PR TITLE
fix for pytest warning: "is using nose-specific method: `setup(self)`"

### DIFF
--- a/radicale/tests/__init__.py
+++ b/radicale/tests/__init__.py
@@ -48,7 +48,7 @@ class BaseTest:
     configuration: config.Configuration
     application: app.Application
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.configuration = config.load()
         self.colpath = tempfile.mkdtemp()
         self.configure({
@@ -62,7 +62,7 @@ class BaseTest:
         self.configuration.update(config_, "test", privileged=True)
         self.application = app.Application(self.configuration)
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         shutil.rmtree(self.colpath)
 
     def request(self, method: str, path: str, data: Optional[str] = None,

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -37,8 +37,8 @@ class TestBaseRequests(BaseTest):
     # Allow skipping sync-token tests, when not fully supported by the backend
     full_sync_token_support: ClassVar[bool] = True
 
-    def setup(self) -> None:
-        BaseTest.setup(self)
+    def setup_method(self) -> None:
+        BaseTest.setup_method(self)
         rights_file_path = os.path.join(self.colpath, "rights")
         with open(rights_file_path, "w") as f:
             f.write("""\

--- a/radicale/tests/test_config.py
+++ b/radicale/tests/test_config.py
@@ -31,10 +31,10 @@ class TestConfig:
 
     colpath: str
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.colpath = tempfile.mkdtemp()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         shutil.rmtree(self.colpath)
 
     def _write_config(self, config_dict: types.CONFIG, name: str) -> str:

--- a/radicale/tests/test_server.py
+++ b/radicale/tests/test_server.py
@@ -54,8 +54,8 @@ class TestBaseServerRequests(BaseTest):
     thread: threading.Thread
     opener: request.OpenerDirector
 
-    def setup(self) -> None:
-        super().setup()
+    def setup_method(self) -> None:
+        super().setup_method()
         self.shutdown_socket, shutdown_socket_out = socket.socketpair()
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             # Find available port
@@ -74,13 +74,13 @@ class TestBaseServerRequests(BaseTest):
             request.HTTPSHandler(context=ssl_context),
             DisabledRedirectHandler)
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         self.shutdown_socket.close()
         try:
             self.thread.join()
         except RuntimeError:  # Thread never started
             pass
-        super().teardown()
+        super().teardown_method()
 
     def request(self, method: str, path: str, data: Optional[str] = None,
                 check: Optional[int] = None, **kwargs

--- a/radicale/tests/test_storage.py
+++ b/radicale/tests/test_storage.py
@@ -35,8 +35,8 @@ from radicale.tests.test_base import TestBaseRequests as _TestBaseRequests
 class TestMultiFileSystem(BaseTest):
     """Tests for multifilesystem."""
 
-    def setup(self) -> None:
-        _TestBaseRequests.setup(cast(_TestBaseRequests, self))
+    def setup_method(self) -> None:
+        _TestBaseRequests.setup_method(cast(_TestBaseRequests, self))
         self.configure({"storage": {"type": "multifilesystem"}})
 
     def test_folder_creation(self) -> None:
@@ -150,8 +150,8 @@ class TestMultiFileSystem(BaseTest):
 class TestMultiFileSystemNoLock(BaseTest):
     """Tests for multifilesystem_nolock."""
 
-    def setup(self) -> None:
-        _TestBaseRequests.setup(cast(_TestBaseRequests, self))
+    def setup_method(self) -> None:
+        _TestBaseRequests.setup_method(cast(_TestBaseRequests, self))
         self.configure({"storage": {"type": "multifilesystem_nolock"}})
 
     test_add_event = _TestBaseRequests.test_add_event
@@ -161,8 +161,8 @@ class TestMultiFileSystemNoLock(BaseTest):
 class TestCustomStorageSystem(BaseTest):
     """Test custom backend loading."""
 
-    def setup(self) -> None:
-        _TestBaseRequests.setup(cast(_TestBaseRequests, self))
+    def setup_method(self) -> None:
+        _TestBaseRequests.setup_method(cast(_TestBaseRequests, self))
         self.configure({"storage": {
             "type": "radicale.tests.custom.storage_simple_sync"}})
 
@@ -181,8 +181,8 @@ class TestCustomStorageSystem(BaseTest):
 class TestCustomStorageSystemCallable(BaseTest):
     """Test custom backend loading with ``callable``."""
 
-    def setup(self) -> None:
-        _TestBaseRequests.setup(cast(_TestBaseRequests, self))
+    def setup_method(self) -> None:
+        _TestBaseRequests.setup_method(cast(_TestBaseRequests, self))
         self.configure({"storage": {
             "type": radicale.tests.custom.storage_simple_sync.Storage}})
 


### PR DESCRIPTION
- `teardown` -> `teardown_method`
- `setup` -> `setup_method`