### PR TITLE
WEB UI: New WebUI Improvements

### DIFF
--- a/radicale/web/internal_data/css/main.css
+++ b/radicale/web/internal_data/css/main.css
@@ -196,6 +196,11 @@ main{
     text-align: center;
 }
 
+#collectionsscene article small[data-name=contentcount]{
+    font-weight: bold;
+    font-style: normal;
+}
+
 #editcollectionscene p span{
     word-wrap:break-word;
     font-weight: bold;
@@ -226,6 +231,12 @@ main{
     text-align: center;
     display: block;
     margin-top: 15px;
+}
+
+.deleteconfirmationtxt{
+    text-align: center;
+    font-size: 1em;
+    font-weight: bold;
 }
 
 .fabcontainer{

--- a/radicale/web/internal_data/index.html
+++ b/radicale/web/internal_data/index.html
@@ -62,6 +62,7 @@
             <span data-name="TASKS">Tasks</span>
             <span data-name="WEBCAL">Webcal</span>
           </small>
+          <small data-name="contentcount"></small>
           <input type="text" data-name="url" value="" readonly="" onfocus="this.setSelectionRange(0, 99999);">
           <p data-name="description" style="word-wrap:break-word;">Description</p>
           <ul>
@@ -131,6 +132,8 @@
             <option value="TASKS">Tasks</option>
             <option value="WEBCAL">Webcal</option>
           </select>
+          <label for="href">HREF:</label>
+          <input data-name="href" type="text">
           <label for="displayname">Title:</label>
           <input data-name="displayname" type="text">
           <label for="description">Description:</label>
@@ -164,7 +167,8 @@
 
       <section id="deletecollectionscene" class="container hidden">
         <h1>Delete Collection</h1>
-        <p>Do you want to delete the collection <span class="title" data-name="title">title</span>? </p>
+        <p>To delete the collection <span class="title" data-name="title">title</span> please enter the phrase <strong data-name="deleteconfirmationtext"></strong> in the box below:</p>
+        <input type="text" class="deleteconfirmationtxt" data-name="confirmationtxt" />
         <p class="red">WARNING: This action cannot be reversed.</p>
         <form>
           <button type="button" class="red" data-name="delete">Delete</button>


### PR DESCRIPTION
Added WebUI improvements as discussed in discussion #1416 in March 2024. 

**New features:**
1. Set the HREF for a _new_ collection
2. Change a calendars components set (Todo, Events, etc) for an existing calendar collection
3. Deleting a collection now requires the user to confirm by typing confirmation text in the dialog
4. The number of entries in a collection is displayed on the collection box

**Screenshots**
<img width="358" alt="202402 - New Web UI - HREF" src="https://github.com/Kozea/Radicale/assets/1935851/9dce1d5b-89e3-4521-b8d7-679b97bc5cb3">
<img width="352" alt="202402 - New Web UI - cal set change" src="https://github.com/Kozea/Radicale/assets/1935851/1a62196b-e0d8-4c7a-8039-abda0edd4277">
<img width="337" alt="202402 - New Web UI - delete confirm" src="https://github.com/Kozea/Radicale/assets/1935851/7eccdd62-a61a-4a3b-8bda-8cd4e4e6bfbd">
<img width="221" alt="202402 - New Web UI - conent count" src="https://github.com/Kozea/Radicale/assets/1935851/13747ab5-eaca-4ddd-97ed-df3dc1709992">

