### PR TITLE
added compatibility with a case-insensitive authentication provider

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -786,6 +786,13 @@ Message displayed in the client when a password is needed.
 
 Default: `Radicale - Password Required`
 
+##### lc_username
+
+Сonvert username to lowercase, must be true for case-insensitive auth 
+providers like ldap, kerberos
+
+Default: `False`
+
 #### rights
 
 ##### type

--- a/config
+++ b/config
@@ -70,6 +70,9 @@
 # Message displayed in the client when a password is needed
 #realm = Radicale - Password Required
 
+# Сonvert username to lowercase, must be true for case-insensitive auth providers
+#lc_username = False
+
 
 [rights]
 

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -44,6 +44,8 @@ def load(configuration: "config.Configuration") -> "BaseAuth":
 
 class BaseAuth:
 
+    _lc_username: bool
+
     def __init__(self, configuration: "config.Configuration") -> None:
         """Initialize BaseAuth.
 
@@ -53,6 +55,7 @@ class BaseAuth:
 
         """
         self.configuration = configuration
+        self._lc_username = configuration.get("auth", "lc_username")
 
     def get_external_login(self, environ: types.WSGIEnviron) -> Union[
             Tuple[()], Tuple[str, str]]:
@@ -67,7 +70,7 @@ class BaseAuth:
         """
         return ()
 
-    def login(self, login: str, password: str) -> str:
+    def _login(self, login: str, password: str) -> str:
         """Check credentials and map login to internal user
 
         ``login`` the login name
@@ -79,3 +82,6 @@ class BaseAuth:
         """
 
         raise NotImplementedError
+
+    def login(self, login: str, password: str) -> str:
+        return self._login(login, password).lower() if self._lc_username else self._login(login, password)

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -127,7 +127,7 @@ class Auth(auth.BaseAuth):
             # assumed plaintext
             return self._plain(hash_value, password)
 
-    def login(self, login: str, password: str) -> str:
+    def _login(self, login: str, password: str) -> str:
         """Validate credentials.
 
         Iterate through htpasswd credential file until login matches, extract

--- a/radicale/auth/none.py
+++ b/radicale/auth/none.py
@@ -27,5 +27,5 @@ from radicale import auth
 
 class Auth(auth.BaseAuth):
 
-    def login(self, login: str, password: str) -> str:
+    def _login(self, login: str, password: str) -> str:
         return login

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -177,7 +177,11 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
         ("delay", {
             "value": "1",
             "help": "incorrect authentication delay",
-            "type": positive_float})])),
+            "type": positive_float}),
+        ("lc_username", {
+            "value": "False",
+            "help": "convert username to lowercase, must be true for case-insensitive auth providers",
+            "type": bool})])),
     ("rights", OrderedDict([
         ("type", {
             "value": "owner_only",


### PR DESCRIPTION
When generating the collection path, be able to use the lowercase username by setting lc_username=True
