### PR TITLE
Log bad put request content

### DIFF
--- a/config
+++ b/config
@@ -120,6 +120,9 @@
 # Don't include passwords in logs
 #mask_passwords = True
 
+# Log bad PUT request content
+#bad_put_request_content = False
+
 
 [headers]
 

--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -80,6 +80,7 @@ class Application(ApplicationPartDelete, ApplicationPartHead,
         """
         super().__init__(configuration)
         self._mask_passwords = configuration.get("logging", "mask_passwords")
+        self._bad_put_request_content = configuration.get("logging", "bad_put_request_content")
         self._auth_delay = configuration.get("auth", "delay")
         self._internal_server = configuration.get("server", "_internal_server")
         self._max_content_length = configuration.get(

--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -3,6 +3,7 @@
 # Copyright © 2008 Pascal Halter
 # Copyright © 2008-2017 Guillaume Ayoub
 # Copyright © 2017-2019 Unrud <unrud@outlook.com>
+# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/app/put.py
+++ b/radicale/app/put.py
@@ -3,6 +3,7 @@
 # Copyright © 2008 Pascal Halter
 # Copyright © 2008-2017 Guillaume Ayoub
 # Copyright © 2017-2018 Unrud <unrud@outlook.com>
+# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/app/put.py
+++ b/radicale/app/put.py
@@ -146,6 +146,8 @@ class ApplicationPartPut(ApplicationBase):
         except Exception as e:
             logger.warning(
                 "Bad PUT request on %r (read_components): %s", path, e, exc_info=True)
+            if self._bad_put_request_content:
+                logger.warning("Bad PUT request content of %r:\n%s", path, content)
             return httputils.BAD_REQUEST
         (prepared_items, prepared_tag, prepared_write_whole_collection,
          prepared_props, prepared_exc_info) = prepare(

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -3,6 +3,7 @@
 # Copyright © 2008 Nicolas Kandel
 # Copyright © 2008 Pascal Halter
 # Copyright © 2017-2019 Unrud <unrud@outlook.com>
+# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -247,6 +247,10 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "info",
             "help": "threshold for the logger",
             "type": logging_level}),
+        ("bad_put_request_content", {
+            "value": "False",
+            "help": "log bad PUT request content",
+            "type": bool}),
         ("mask_passwords", {
             "value": "True",
             "help": "mask passwords in logs",


### PR DESCRIPTION
extension to support diagnostics for items which `vobject` don't like without enabling debug mode on global level

supporting 
- https://github.com/Kozea/Radicale/issues/1492