### PR TITLE
(#1485) If an event comes with a dtstart specified as a date then in …

### DIFF
--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -1691,14 +1691,14 @@ permissions: RrWw""")
                 uids.append(line)
 
             if line.startswith("RECURRENCE-ID:"):
-                assert line in ["RECURRENCE-ID:20060103T000000Z", "RECURRENCE-ID:20060104T000000Z", "RECURRENCE-ID:20060105T000000Z"]
+                assert line in ["RECURRENCE-ID:20060103", "RECURRENCE-ID:20060104", "RECURRENCE-ID:20060105"]
                 recurrence_ids.append(line)
 
             if line.startswith("DTSTART:"):
-                assert line == "DTSTART:20060102T000000Z"
+                assert line == "DTSTART:20060102"
 
             if line.startswith("DTEND:"):
-                assert line == "DTEND:20060103T000000Z"
+                assert line == "DTEND:20060103"
 
         assert len(uids) == 3
         assert len(set(recurrence_ids)) == 3


### PR DESCRIPTION
if an event comes to us with a dtstart specified as a date then in the response we return the date, not datetime
