### PR TITLE
add support for auth.type=denyall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.dev
+* Enhancement: add support for auth.type=denyall (will be default for security reasons in upcoming releases)
 
 ## 3.2.1
 

--- a/config
+++ b/config
@@ -53,7 +53,7 @@
 [auth]
 
 # Authentication method
-# Value: none | htpasswd | remote_user | http_x_remote_user
+# Value: none | htpasswd | remote_user | http_x_remote_user | denyall
 #type = none
 
 # Htpasswd filename

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -33,6 +33,7 @@ from typing import Sequence, Tuple, Union
 from radicale import config, types, utils
 
 INTERNAL_TYPES: Sequence[str] = ("none", "remote_user", "http_x_remote_user",
+                                 "denyall",
                                  "htpasswd")
 
 

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -2,7 +2,8 @@
 # Copyright © 2008 Nicolas Kandel
 # Copyright © 2008 Pascal Halter
 # Copyright © 2008-2017 Guillaume Ayoub
-# Copyright © 2017-2018 Unrud <unrud@outlook.com>
+# Copyright © 2017-2022 Unrud <unrud@outlook.com>
+# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/auth/denyall.py
+++ b/radicale/auth/denyall.py
@@ -1,0 +1,30 @@
+# This file is part of Radicale - CalDAV and CardDAV server
+# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+A dummy backend that denies any username and password.
+
+Used as default for security reasons.
+
+"""
+
+from radicale import auth
+
+
+class Auth(auth.BaseAuth):
+
+    def _login(self, login: str, password: str) -> str:
+        return ""

--- a/radicale/tests/test_auth.py
+++ b/radicale/tests/test_auth.py
@@ -152,3 +152,11 @@ class TestBaseAuthRequests(BaseTest):
         """Custom authentication."""
         self.configure({"auth": {"type": "radicale.tests.custom.auth"}})
         self.propfind("/tmp/", login="tmp:")
+
+    def test_none(self) -> None:
+        self.configure({"auth": {"type": "none"}})
+        self.propfind("/tmp/", login="tmp:")
+
+    def test_denyall(self) -> None:
+        self.configure({"auth": {"type": "denyall"}})
+        self.propfind("/tmp/", login="tmp:", check=401)

--- a/radicale/tests/test_auth.py
+++ b/radicale/tests/test_auth.py
@@ -1,7 +1,8 @@
 # This file is part of Radicale - CalDAV and CardDAV server
 # Copyright © 2012-2016 Jean-Marc Martins
 # Copyright © 2012-2017 Guillaume Ayoub
-# Copyright © 2017-2019 Unrud <unrud@outlook.com>
+# Copyright © 2017-2022 Unrud <unrud@outlook.com>
+# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
will be default for security reasons in upcoming releases

related to https://github.com/Kozea/Radicale/issues/1510