### PR TITLE
Replace has_uid with Filename Check for Performance Improvements

### DIFF
--- a/radicale/app/move.py
+++ b/radicale/app/move.py
@@ -3,6 +3,7 @@
 # Copyright © 2008 Pascal Halter
 # Copyright © 2008-2017 Guillaume Ayoub
 # Copyright © 2017-2018 Unrud <unrud@outlook.com>
+# Copyright © 2024 koalyorg <info@koaly.org>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
-
+import os
 import posixpath
 import re
 from http import client
@@ -98,14 +99,16 @@ class ApplicationPartMove(ApplicationBase):
                 return httputils.FORBIDDEN
             if to_item and environ.get("HTTP_OVERWRITE", "F") != "T":
                 return httputils.PRECONDITION_FAILED
+            to_href = posixpath.basename(pathutils.strip_path(to_path))
+            filename, _ = os.path.splitext(to_path)
+            # ensure to_path matches UID
             if (to_item and item.uid != to_item.uid or
                     not to_item and
                     to_collection.path != item.collection.path and
-                    to_collection.has_uid(item.uid)):
+                    item.uid != filename):
                 return self._webdav_error_response(
                     client.CONFLICT, "%s:no-uid-conflict" % (
                         "C" if collection_tag == "VCALENDAR" else "CR"))
-            to_href = posixpath.basename(pathutils.strip_path(to_path))
             try:
                 self._storage.move(item, to_collection, to_href)
             except ValueError as e:

--- a/radicale/app/put.py
+++ b/radicale/app/put.py
@@ -4,6 +4,7 @@
 # Copyright © 2008-2017 Guillaume Ayoub
 # Copyright © 2017-2018 Unrud <unrud@outlook.com>
 # Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
+# Copyright © 2024 koalyorg <info@koaly.org>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +20,7 @@
 # along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
+import os
 import posixpath
 import socket
 import sys
@@ -226,13 +228,15 @@ class ApplicationPartPut(ApplicationBase):
             else:
                 assert not isinstance(item, storage.BaseCollection)
                 prepared_item, = prepared_items
+                href = posixpath.basename(pathutils.strip_path(path))
+                filename, _ = os.path.splitext(href)
+                # ensure filename matches UID
                 if (item and item.uid != prepared_item.uid or
-                        not item and parent_item.has_uid(prepared_item.uid)):
+                        not item and filename != prepared_item.uid):
                     return self._webdav_error_response(
                         client.CONFLICT, "%s:no-uid-conflict" % (
                             "C" if tag == "VCALENDAR" else "CR"))
 
-                href = posixpath.basename(pathutils.strip_path(path))
                 try:
                     etag = parent_item.upload(href, prepared_item).etag
                     hook_notification_item = HookNotificationItem(

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -158,13 +158,6 @@ class BaseCollection:
                 continue
             yield item, simple and (start <= istart or iend <= end)
 
-    def has_uid(self, uid: str) -> bool:
-        """Check if a UID exists in the collection."""
-        for item in self.get_all():
-            if item.uid == uid:
-                return True
-        return False
-
     def upload(self, href: str, item: "radicale_item.Item") -> (
             "radicale_item.Item"):
         """Upload a new or replace an existing item."""


### PR DESCRIPTION
**Issue:**
When using Radicale with a larger number of items, the system becomes very slow (#1282). This performance issue arises because, on each PUT/MOVE operation, the has_uid function is called. This function loads all items (self.get_all()) to check if the specified UID is unique.

**Solution:**
Instead of loading all items, this patch ensures that the filename matches the UID, thereby ensuring that the UIDs remain unique without the need to load all items for such.

**Changes:**
- Removes has_uid function
- Add check if filename exists with <UID>.vcf in PUT and MOVE

**Improvements**
- Significant performance improvement for large collections when performing PUT or MOVE.

Please review the changes and provide feedback. Thank you.