### PR TITLE
Remove unexpected control codes from ICS files

### DIFF
--- a/radicale/item/__init__.py
+++ b/radicale/item/__init__.py
@@ -49,6 +49,12 @@ def read_components(s: str) -> List[vobject.base.Component]:
     s = re.sub(r"^(PHOTO(?:;[^:\r\n]*)?;ENCODING=b(?:;[^:\r\n]*)?:)"
                r"data:[^;,\r\n]*;base64,", r"\1", s,
                flags=re.MULTILINE | re.IGNORECASE)
+    # Workaround for bug with malformed ICS files containing control codes
+    # Filter out all control codes except those we expect to find:
+    #  * 0x09 Horizontal Tab
+    #  * 0x0A Line Feed
+    #  * 0x0D Carriage Return
+    s = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F]', '', s)
     return list(vobject.readComponents(s, allowQP=True))
 
 


### PR DESCRIPTION
We are running Radicale 3.2.2 as packaged in Debian trixie (Debian package version 3.2.2-1). We have approximately 100 users mostly using Thunderbird.

We have run into a problem where users sometimes upload ICS files that are corrupted. They contain unexpected control codes (ie characters with codepoints below 32 that are not tab, carriage return or line feed). Radicale seems to accept these ICS files and store them verbatim on disk, then later return them to the client software. This leads to Thunderbird refusing to accept the XML that Radicale produces in a 207 Multi-Status response, with Thunderbird giving an "XML Parsing Error: not well-formed" error. Because there are multiple events in a single response a single malformed event can result in a number of well-formed events being effectively ignored by the client software.

We have developed the attached patch which strips out all unexpected control codes from ingested ICS files. When a corrupted ICS file is presented to Radicale by the client software it is fixed on ingest and before any further processing, including storing on disk. This has fixed the problem for us.

I don't believe the scrubbing performed here should negatively affect any well-formed file since they should never contain the control codes that the scrubbing removes.