### PR TITLE
split tox jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Test dependencies
         run: pip install tox
       - name: Test
-        run: tox
+        run: tox -e py
       - name: Install Coveralls
         if: github.event_name == 'push'
         run: pip install coveralls
@@ -46,3 +46,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github --finish
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install tox
+        run: pip install tox
+      - name: Lint
+        run: tox -e flake8,mypy,isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,25 +2,31 @@
 addopts = --typeguard-packages=radicale
 
 [tox:tox]
+min_version = 4.0
+envlist = py, flake8, isort, mypy
 
 [testenv]
-extras = test
+extras =
+    test
 deps =
-    flake8
-    isort
-    # mypy installation fails with pypy<3.9
-    mypy; implementation_name!='pypy' or python_version>='3.9'
-    types-setuptools
+    pytest
     pytest-cov
-commands =
-    flake8 .
-    isort --check --diff .
-    # Run mypy if it's installed
-    python -c 'import importlib.util, subprocess, sys; \
-               importlib.util.find_spec("mypy") \
-                   and sys.exit(subprocess.run(["mypy", "."]).returncode) \
-                   or print("Skipped: mypy is not installed")'
-    pytest -r s --cov --cov-report=term --cov-report=xml .
+commands = pytest -r s --cov --cov-report=term --cov-report=xml .
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 .
+skip_install = True
+
+[testenv:isort]
+deps = isort
+commands = isort --check --diff .
+skip_install = True
+
+[testenv:mypy]
+deps = mypy
+commands = mypy .
+skip_install = True
 
 [tool:isort]
 known_standard_library = _dummy_thread,_thread,abc,aifc,argparse,array,ast,asynchat,asyncio,asyncore,atexit,audioop,base64,bdb,binascii,binhex,bisect,builtins,bz2,cProfile,calendar,cgi,cgitb,chunk,cmath,cmd,code,codecs,codeop,collections,colorsys,compileall,concurrent,configparser,contextlib,contextvars,copy,copyreg,crypt,csv,ctypes,curses,dataclasses,datetime,dbm,decimal,difflib,dis,distutils,doctest,dummy_threading,email,encodings,ensurepip,enum,errno,faulthandler,fcntl,filecmp,fileinput,fnmatch,formatter,fpectl,fractions,ftplib,functools,gc,getopt,getpass,gettext,glob,grp,gzip,hashlib,heapq,hmac,html,http,imaplib,imghdr,imp,importlib,inspect,io,ipaddress,itertools,json,keyword,lib2to3,linecache,locale,logging,lzma,macpath,mailbox,mailcap,marshal,math,mimetypes,mmap,modulefinder,msilib,msvcrt,multiprocessing,netrc,nis,nntplib,ntpath,numbers,operator,optparse,os,ossaudiodev,parser,pathlib,pdb,pickle,pickletools,pipes,pkgutil,platform,plistlib,poplib,posix,posixpath,pprint,profile,pstats,pty,pwd,py_compile,pyclbr,pydoc,queue,quopri,random,re,readline,reprlib,resource,rlcompleter,runpy,sched,secrets,select,selectors,shelve,shlex,shutil,signal,site,smtpd,smtplib,sndhdr,socket,socketserver,spwd,sqlite3,sre,sre_compile,sre_constants,sre_parse,ssl,stat,statistics,string,stringprep,struct,subprocess,sunau,symbol,symtable,sys,sysconfig,syslog,tabnanny,tarfile,telnetlib,tempfile,termios,test,textwrap,threading,time,timeit,tkinter,token,tokenize,trace,traceback,tracemalloc,tty,turtle,turtledemo,types,typing,unicodedata,unittest,urllib,uu,uuid,venv,warnings,wave,weakref,webbrowser,winreg,winsound,wsgiref,xdrlib,xml,xmlrpc,zipapp,zipfile,zipimport,zlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,17 +14,17 @@ deps =
 commands = pytest -r s --cov --cov-report=term --cov-report=xml .
 
 [testenv:flake8]
-deps = flake8
+deps = flake8==7.1.0
 commands = flake8 .
 skip_install = True
 
 [testenv:isort]
-deps = isort
+deps = isort==5.13.2
 commands = isort --check --diff .
 skip_install = True
 
 [testenv:mypy]
-deps = mypy
+deps = mypy==1.11.0
 commands = mypy .
 skip_install = True
 


### PR DESCRIPTION
You don't need to run isort, mypy and flake8 as many time as you have environments (~20 here).
* you save yourself Github Actions CI minutes (the Windows one count double and macOS count 4 times)
* you get faster feedback (the ubuntu 3.11 test one runs under 20 seconds)(we could probably stop the test matrix as soon as this one fail, to avoid useless runs).
* no more dirty python / mypy version check hack.
* you save the planet

Btw, mypy, isort and flake8 version should be pinned. If not, you are at risk than any new release of any of those 3 turns your CI red overnight.