### PR TITLE
fix logger-warn-leftovers

### DIFF
--- a/radicale/__init__.py
+++ b/radicale/__init__.py
@@ -61,7 +61,7 @@ def _get_application_instance(config_path: str, wsgi_errors: types.ErrorStream
                     if not miss and source != "default config":
                         default_config_active = False
                 if default_config_active:
-                    logger.warn("%s", "No config file found/readable - only default config is active")
+                    logger.warning("%s", "No config file found/readable - only default config is active")
                 _application_instance = Application(configuration)
     if _application_config_path != config_path:
         raise ValueError("RADICALE_CONFIG must not change: %r != %r" %

--- a/radicale/__main__.py
+++ b/radicale/__main__.py
@@ -175,7 +175,7 @@ def run() -> None:
             default_config_active = False
 
     if default_config_active:
-        logger.warn("%s", "No config file found/readable - only default config is active")
+        logger.warning("%s", "No config file found/readable - only default config is active")
 
     if args_ns.verify_storage:
         logger.info("Verifying storage")

--- a/radicale/server.py
+++ b/radicale/server.py
@@ -291,7 +291,7 @@ def serve(configuration: config.Configuration,
             try:
                 getaddrinfo = socket.getaddrinfo(address_port[0], address_port[1], 0, socket.SOCK_STREAM, socket.IPPROTO_TCP)
             except OSError as e:
-                logger.warn("cannot retrieve IPv4 or IPv6 address of '%s': %s" % (format_address(address_port), e))
+                logger.warning("cannot retrieve IPv4 or IPv6 address of '%s': %s" % (format_address(address_port), e))
                 continue
             logger.debug("getaddrinfo of '%s': %s" % (format_address(address_port), getaddrinfo))
             for (address_family, socket_kind, socket_proto, socket_flags, socket_address) in getaddrinfo:
@@ -299,7 +299,7 @@ def serve(configuration: config.Configuration,
                 try:
                     server = server_class(configuration, address_family, (socket_address[0], socket_address[1]), RequestHandler)
                 except OSError as e:
-                    logger.warn("cannot create server socket on '%s': %s" % (format_address(socket_address), e))
+                    logger.warning("cannot create server socket on '%s': %s" % (format_address(socket_address), e))
                     continue
                 servers[server.socket] = server
                 server.set_app(application)


### PR DESCRIPTION
reported by

```
radicale/__init__.py:64: error: "Logger" has no attribute "warn"  [attr-defined]
radicale/server.py:294: error: "Logger" has no attribute "warn"  [attr-defined]
radicale/server.py:302: error: "Logger" has no attribute "warn"  [attr-defined]
radicale/__main__.py:178: error: "Logger" has no attribute "warn"  [attr-defined]
Found 4 errors in 3 files (checked 74 source files)
```