### PR TITLE
remove unused requirement "typeguard"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.dev
 * Enhancement: remove unexpected control codes from uploaded items
+* Drop: remove unused requirement "typeguard"
 
 ## 3.2.2
 * Enhancement: add support for auth.type=denyall (will be default for security reasons in upcoming releases)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [tool:pytest]
-addopts = --typeguard-packages=radicale
 
 [tox:tox]
 min_version = 4.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = ["defusedxml", "passlib", "vobject>=0.9.6",
                     "pika>=1.1.0",
                     ]
 bcrypt_requires = ["bcrypt"]
-test_requires = ["pytest>=7", "typeguard<4.3", "waitress", *bcrypt_requires]
+test_requires = ["pytest>=7", "waitress", *bcrypt_requires]
 
 setup(
     name="Radicale",


### PR DESCRIPTION
during investigation of https://github.com/Kozea/Radicale/pull/1517 it was found that _typeguard_ is not used at all and therefore requirements removed with this PR.