### PR TITLE
Fix changelog link

### DIFF
--- a/v3.html
+++ b/v3.html
@@ -286,7 +286,7 @@ You can login with any username and password.</p>
 </section>
 <section class="level4" id="whats-new">
 <h4>What's New? <a class="headerlink" href="#whats-new">&para;</a></h4>
-<p>Read the <a href="https://github.com/Kozea/Radicale/blob/v3/CHANGELOG.md">changelog
+<p>Read the <a href="https://github.com/Kozea/Radicale/blob/master/CHANGELOG.md">changelog
 on GitHub.</a></p>
 </section>
 </section>


### PR DESCRIPTION
The front page of `radicale.org` redirects to `v3.html`. The What’s New link in `v3.html` points at `CHANGELOG.md` in the `v3` branch, which only has information up to 3.1.8. Point it instead at `CHANGELOG.md` in the `master` branch, which has information up to 3.2.3.