### PR TITLE
Implementing group calendars and increase perfomance

### DIFF
--- a/config
+++ b/config
@@ -59,7 +59,7 @@
 # URI to the LDAP server
 #ldap_uri = ldap://localhost
 
-# The base DN of the LDAP server
+# The base DN where the user accounts have to be searched
 #ldap_base = ##BASE_DN##
 
 # The reader DN of the LDAP server
@@ -71,8 +71,8 @@
 # If the ldap groups of the user need to be loaded
 #ldap_load_groups = True
 
-# Value: none | htpasswd | remote_user | http_x_remote_user | denyall
-#type = none
+# The filter to find the DN of the user. This filter must contain a python-style placeholder for the login
+#ldap_filter = (&(objectClass=person)(cn={0}))
 
 # Htpasswd filename
 #htpasswd_filename = /etc/radicale/users

--- a/radicale/app/propfind.py
+++ b/radicale/app/propfind.py
@@ -392,7 +392,8 @@ class ApplicationPartPropfind(ApplicationBase):
             return httputils.REQUEST_TIMEOUT
         with self._storage.acquire_lock("r", user):
             items_iter = iter(self._storage.discover(
-                path, environ.get("HTTP_DEPTH", "0")))
+                path, environ.get("HTTP_DEPTH", "0"),
+                None, self._rights._user_groups))
             # take root item for rights checking
             item = next(items_iter, None)
             if not item:

--- a/radicale/rights/from_file.py
+++ b/radicale/rights/from_file.py
@@ -66,8 +66,8 @@ class Rights(rights.BaseRights):
         if not self._log_rights_rule_doesnt_match_on_debug:
             logger.debug("logging of rules which doesn't match suppressed by config/option [logging] rights_rule_doesnt_match_on_debug")
         for section in self._rights_config.sections():
-            group_match = False
-            user_match = False
+            group_match = None
+            user_match = None
             try:
                 user_pattern = self._rights_config.get(section, "user", fallback="")
                 collection_pattern = self._rights_config.get(section, "collection")

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -24,6 +24,7 @@ Take a look at the class ``BaseCollection`` if you want to implement your own.
 """
 
 import json
+from typing import Callable, ContextManager, Iterator, Optional, Set, cast
 import xml.etree.ElementTree as ET
 from hashlib import sha256
 from typing import (Iterable, Iterator, Mapping, Optional, Sequence, Set,
@@ -282,8 +283,11 @@ class BaseStorage:
         """
         self.configuration = configuration
 
-    def discover(self, path: str, depth: str = "0") -> Iterable[
-            "types.CollectionOrItem"]:
+    def discover(
+            self, path: str, depth: str = "0", 
+            child_context_manager: Optional[
+            Callable[[str, Optional[str]], ContextManager[None]]] = None, 
+            user_groups: Set[str] = set([])) -> Iterable["types.CollectionOrItem"]:
         """Discover a list of collections under the given ``path``.
 
         ``path`` is sanitized.

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -24,11 +24,10 @@ Take a look at the class ``BaseCollection`` if you want to implement your own.
 """
 
 import json
-from typing import Callable, ContextManager, Iterator, Optional, Set, cast
 import xml.etree.ElementTree as ET
 from hashlib import sha256
-from typing import (Iterable, Iterator, Mapping, Optional, Sequence, Set,
-                    Tuple, Union, overload)
+from typing import (Callable, ContextManager, Iterable, Iterator, Mapping,
+                    Optional, Sequence, Set, Tuple, Union, cast, overload)
 
 import vobject
 

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -27,7 +27,7 @@ import json
 import xml.etree.ElementTree as ET
 from hashlib import sha256
 from typing import (Callable, ContextManager, Iterable, Iterator, Mapping,
-                    Optional, Sequence, Set, Tuple, Union, cast, overload)
+                    Optional, Sequence, Set, Tuple, Union, overload)
 
 import vobject
 
@@ -283,9 +283,9 @@ class BaseStorage:
         self.configuration = configuration
 
     def discover(
-            self, path: str, depth: str = "0", 
+            self, path: str, depth: str = "0",
             child_context_manager: Optional[
-            Callable[[str, Optional[str]], ContextManager[None]]] = None, 
+            Callable[[str, Optional[str]], ContextManager[None]]] = None,
             user_groups: Set[str] = set([])) -> Iterable["types.CollectionOrItem"]:
         """Discover a list of collections under the given ``path``.
 

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -19,7 +19,7 @@
 import os
 import posixpath
 import base64
-from typing import Callable, ContextManager, Iterator, Optional, cast
+from typing import Callable, ContextManager, Iterator, Optional, Set, cast
 
 from radicale import pathutils, types
 from radicale.log import logger
@@ -36,9 +36,10 @@ def _null_child_context_manager(path: str,
 class StoragePartDiscover(StorageBase):
 
     def discover(
-            self, path: str, depth: str = "0", child_context_manager: Optional[
-                Callable[[str, Optional[str]], ContextManager[None]]] = None,
-                user_groups: Set[str] = set([])
+            self, path: str, depth: str = "0", 
+            child_context_manager: Optional[
+            Callable[[str, Optional[str]], ContextManager[None]]] = None, 
+            user_groups: Set[str] = set([])
             ) -> Iterator[types.CollectionOrItem]:
         # assert isinstance(self, multifilesystem.Storage)
         if child_context_manager is None:

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -36,9 +36,9 @@ def _null_child_context_manager(path: str,
 class StoragePartDiscover(StorageBase):
 
     def discover(
-            self, path: str, depth: str = "0", 
+            self, path: str, depth: str = "0",
             child_context_manager: Optional[
-            Callable[[str, Optional[str]], ContextManager[None]]] = None, 
+            Callable[[str, Optional[str]], ContextManager[None]]] = None,
             user_groups: Set[str] = set([])
             ) -> Iterator[types.CollectionOrItem]:
         # assert isinstance(self, multifilesystem.Storage)

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Radicale.  If not, see <http://www.gnu.org/licenses/>.
 
+import base64
 import os
 import posixpath
-import base64
 from typing import Callable, ContextManager, Iterator, Optional, Set, cast
 
 from radicale import pathutils, types


### PR DESCRIPTION
### Implementing rights based only on group membership
I've adapted rights/from_file.py to be able to handle sections without user pattern.

### Increase perfomance
In rights/from_file.py the configuration file was opened and parsed by all call of  authorization. I've moved the opening and parsing of the configuration file into __init__ to increase the performance of the server. As side effect the server must be restarted when the rights configuration was changed.

### Implementing group calendars
I've enhenced the discover function in StoragePartDiscover class to handle group calendars. A new for loop was introduced which walks on the user_groups an check if a group calendar directory does exists. In case of yes an additional collection will be yield.

- The group calendar will be placed under collection_root_folder/GROUPS.
- The name of the calendar directory is the base64 encoded group name.
- The group calneder folders will not be created automaticaly. This must be created manualy. I'll provide a script on wiki.