### PR TITLE
Implementing ssl connection for ldap auth

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -834,9 +834,30 @@ Default: `(cn={0})`
 
 ##### ldap_load_groups
 
-Load the ldap groups of the authenticated user. These groups can be used later on to define rights.
+Load the ldap groups of the authenticated user. These groups can be used later on to define rights. This also gives you access to the group calendars, if they exist.
+* The group calendar will be placed under collection_root_folder/GROUPS
+* The name of the calendar directory is the base64 encoded group name.
+* The group calneder folders will not be created automaticaly. This must be created manualy. Here you can find a script to create group calneder folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
 
 Default: False
+
+##### ldap_use_ssl
+
+Use ssl on the ldap connection
+
+Default: False
+
+##### ldap_ssl_verify_mode
+
+The certifikat verification mode. NONE, OPTIONAL or REQUIRED
+
+Default: REQUIRED
+
+##### ldap_ssl_ca_file
+
+The path to the CA file in pem format which is used to certificate the server certificate
+
+Default:
 
 ##### lc_username
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -837,7 +837,7 @@ Default: `(cn={0})`
 Load the ldap groups of the authenticated user. These groups can be used later on to define rights. This also gives you access to the group calendars, if they exist.
 * The group calendar will be placed under collection_root_folder/GROUPS
 * The name of the calendar directory is the base64 encoded group name.
-* The group calneder folders will not be created automaticaly. This must be created manualy. Here you can find a script to create group calneder folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
+* The group calneder folders will not be created automaticaly. This must be created manualy. [Here](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create group calneder folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
 
 Default: False
 

--- a/config
+++ b/config
@@ -72,7 +72,16 @@
 #ldap_load_groups = True
 
 # The filter to find the DN of the user. This filter must contain a python-style placeholder for the login
-#ldap_filter = (&(objectClass=person)(cn={0}))
+#ldap_filter = (&(objectClass=person)(uid={0}))
+
+# Use ssl on the ldap connection
+#ldap_use_ssl = False
+
+# The certifikat verification mode. NONE, OPTIONAL, default is REQUIRED
+#ldap_ssl_verify_mode = REQUIRED
+
+# The path to the CA file in pem format which is used to certificate the server certificate
+#ldap_ssl_ca_file =
 
 # Htpasswd filename
 #htpasswd_filename = /etc/radicale/users

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -25,7 +25,7 @@ Following parameters are needed in the configuration:
 Following parameters controls SSL connections:
    ldap_use_ssl   If the connection
    ldap_ssl_verify_mode The certifikat verification mode. NONE, OPTIONAL, default is REQUIRED
-   ldap_ssl_ca_file 
+   ldap_ssl_ca_file
 
 """
 import ssl
@@ -42,11 +42,9 @@ class Auth(auth.BaseAuth):
     _ldap_filter: str
     _ldap_load_groups: bool
     _ldap_version: int = 3
-    #SSL stuff
     _ldap_use_ssl: bool = False
     _ldap_ssl_verify_mode: int = ssl.CERT_REQUIRED
     _ldap_ssl_ca_file: str = ""
-
 
     def __init__(self, configuration: config.Configuration) -> None:
         super().__init__(configuration)

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -29,6 +29,7 @@ Following parameters controls SSL connections:
 
 """
 import ssl
+
 from radicale import auth, config
 from radicale.log import logger
 

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -215,6 +215,18 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "False",
             "help": "load the ldap groups of the authenticated user",
             "type": bool}),
+        ("ldap_use_ssl", {
+            "value": "False",
+            "help": "Use ssl on the ldap connection",
+            "type": bool}),
+        ("ldap_ssl_verify_mode", {
+            "value": "REQUIRED",
+            "help": "The certifikat verification mode. NONE, OPTIONAL, default is REQUIRED",
+            "type": str}),
+        ("ldap_ssl_ca_file", {
+            "value": "",
+            "help": "The path to the CA file in pem format which is used to certificate the server certificate",
+            "type": str}),
         ("strip_domain", {
             "value": "False",
             "help": "strip domain from username",


### PR DESCRIPTION
3 new ldap parameters was introduced:
**ldap_use_ssl** to trigger the usage of ssl for ldap connection
**ldap_ssl_verify_mode** to set how the certificates need to be verified
**ldap_ssl_ca_file** he path to the CA file in pem format which is used to certificate the server certificate