### PR TITLE
fix casing in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This file is intended to be used apart from the containing source code tree.
 
-FROM python:3-alpine as builder
+FROM python:3-alpine AS builder
 
 # Version of Radicale (e.g. v3)
 ARG VERSION=master

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3-alpine as builder
+FROM python:3-alpine AS builder
 
 # Optional dependencies (e.g. bcrypt)
 ARG DEPENDENCIES=bcrypt


### PR DESCRIPTION
when building this docker threw a warning
`- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)`
so this PR fixes that tiny thing