### PR TITLE
warn of possible client-side SSL requirement

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1171,6 +1171,11 @@ In some clients you can just enter the URL of the Radicale server
 enter the URL of the collection directly
 (e.g. `http://localhost:5232/user/calendar`).
 
+Some clients (notably macOS's Calendar.app) may silently refuse to include
+account credentials over unsecured HTTP, leading to unexpected authentication
+failures. In these cases, you want to make sure the Radicale server is
+[accessible over HTTPS](#ssl).
+
 #### DAVx⁵
 
 Enter the URL of the Radicale server (e.g. `http://localhost:5232`) and your


### PR DESCRIPTION
### context

After going through basic setup & configuration, I had a difficult time getting macOS to successfully talk to my Radicale instance. It kept saying it was "Unable to verify account name or password".

Trying on other clients worked without issue. Turns out that macOS was not actually authenticating its requests, instead trying to access the server as an anonymous user.

After getting a LetsEncrypt cert and enabling SSL in the Radicale configuration, the problem went away, macOS was able to connect & sync without further issues.

I figured it would be good to point this case/behavior out in the docs, to help others playing with simple setups. Otherwise the initial impression may be that Radicale isn't compatible with macOS for whatever reason.

### details

The comment here talks about Calendar.app. It may be more accurate to say "macOS's Internet Accounts system", but I suspect affected users are more likely to be searching for Calendar.app mentions in particular.

Since there is no section talking about SSL setup by itself (the reverse proxy section has broader scope) I just link to the `ssl` configuration option directly.

I was surprised to not find macOS or its stock apps mentioned in the Supported Clients section at all. Calendar.app passes my smoke tests, are there any further requirements for getting added to the "known good" list?

(Lastly: thank you all for this software!)