### PR TITLE
Update DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -537,7 +537,6 @@ location /radicale/ {
     # Place the files somewhere nginx is allowed to access (e.g. /etc/nginx/...).
     proxy_ssl_certificate         /path/to/client_cert.pem;
     proxy_ssl_certificate_key     /path/to/client_key.pem;
-    proxy_ssl_trusted_certificate /path/to/server_cert.pem;
 }
 ```
 


### PR DESCRIPTION
remove unnecessary call for `proxy_ssl_trusted_certificate` in example SSL-enabled reverse proxy config

Per the [CertBot documentation](https://eff-certbot.readthedocs.io/en/latest/using.html#where-are-my-certificates), including `proxy_ssl_trusted_certificate` is only necessary if you're doing OCSP stapling, which requires some additional config that's probably outside the scope of radicale's documentation