### PR TITLE
Fix 'Replacement index 0 out of range for positional args tuple'

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -888,7 +888,7 @@ Default: `(cn={0})`
 Load the ldap groups of the authenticated user. These groups can be used later on to define rights. This also gives you access to the group calendars, if they exist.
 * The group calendar will be placed under collection_root_folder/GROUPS
 * The name of the calendar directory is the base64 encoded group name.
-* The group calendar folders will not be created automaticaly. This must be created manualy. [Here](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create group calendar folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
+* The group calendar folders will not be created automaticaly. This must be created manually. [Here](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create group calendar folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
 
 Default: False
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -888,7 +888,7 @@ Default: `(cn={0})`
 Load the ldap groups of the authenticated user. These groups can be used later on to define rights. This also gives you access to the group calendars, if they exist.
 * The group calendar will be placed under collection_root_folder/GROUPS
 * The name of the calendar directory is the base64 encoded group name.
-* The group calneder folders will not be created automaticaly. This must be created manualy. [Here](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create group calneder folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
+* The group calendar folders will not be created automaticaly. This must be created manualy. [Here](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create group calendar folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
 
 Default: False
 

--- a/radicale/rights/from_file.py
+++ b/radicale/rights/from_file.py
@@ -84,7 +84,8 @@ class Rights(rights.BaseRights):
                     collection_pattern.format(
                         *(re.escape(s) for s in user_match.groups()),
                         user=escaped_user), sane_path)
-                group_collection_match = re.fullmatch(collection_pattern.format(user=escaped_user), sane_path)
+                group_collection_match = group_match and re.fullmatch(
+                    collection_pattern.format(user=escaped_user), sane_path)
             except Exception as e:
                 raise RuntimeError("Error in section %r of rights file %r: "
                                    "%s" % (section, self._filename, e)) from e

--- a/radicale/tests/__init__.py
+++ b/radicale/tests/__init__.py
@@ -29,6 +29,7 @@ import wsgiref.util
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import quote
 
 import defusedxml.ElementTree as DefusedET
 import vobject
@@ -167,7 +168,7 @@ class BaseTest:
         assert answer is not None
         responses = self.parse_responses(answer)
         if kwargs.get("HTTP_DEPTH", "0") == "0":
-            assert len(responses) == 1 and path in responses
+            assert len(responses) == 1 and quote(path) in responses
         return status, responses
 
     def proppatch(self, path: str, data: Optional[str] = None,


### PR DESCRIPTION
Fixes #1611

- Follow the pattern of the user match and skip the `group_collection_match` if no groups match. This allows capturing groups to be used when the user matches but the LDAP group doesn't.
- Add tests for capturing group using the example from the [sample rights file](https://github.com/Kozea/Radicale/blob/ff5fae1663590ea70b425144a5270fd2b448dad6/rights#L121-L128).
