### PR TITLE
Disable overloading BaseAuth login method

### DIFF
--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -29,7 +29,7 @@ Take a look at the class ``BaseAuth`` if you want to implement your own.
 
 """
 
-from typing import Sequence, Set, Tuple, Union
+from typing import Sequence, Set, Tuple, Union, final
 
 from radicale import config, types, utils
 from radicale.log import logger
@@ -49,7 +49,6 @@ def load(configuration: "config.Configuration") -> "BaseAuth":
         logger.warning("All access is blocked by: '[auth] type=denyall'")
     return utils.load_plugin(INTERNAL_TYPES, "auth", "Auth", BaseAuth,
                              configuration)
-
 
 class BaseAuth:
 
@@ -102,6 +101,7 @@ class BaseAuth:
 
         raise NotImplementedError
 
+    @final
     def login(self, login: str, password: str) -> str:
         if self._lc_username:
             login = login.lower()

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -50,6 +50,7 @@ def load(configuration: "config.Configuration") -> "BaseAuth":
     return utils.load_plugin(INTERNAL_TYPES, "auth", "Auth", BaseAuth,
                              configuration)
 
+
 class BaseAuth:
 
     _ldap_groups: Set[str] = set([])

--- a/radicale/auth/dovecot.py
+++ b/radicale/auth/dovecot.py
@@ -32,7 +32,7 @@ class Auth(auth.BaseAuth):
         self.timeout = 5
         self.request_id_gen = itertools.count(1)
 
-    def login(self, login, password):
+    def _login(self, login, password):
         """Validate credentials.
 
         Check if the ``login``/``password`` pair is valid according to Dovecot.

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -202,7 +202,7 @@ class Auth(auth.BaseAuth):
             pass
         return ""
 
-    def login(self, login: str, password: str) -> str:
+    def _login(self, login: str, password: str) -> str:
         """Validate credentials.
         In first step we make a connection to the ldap server with the ldap_reader_dn credential.
         In next step the DN of the user to authenticate will be searched.

--- a/radicale/tests/custom/auth.py
+++ b/radicale/tests/custom/auth.py
@@ -29,7 +29,7 @@ from radicale import auth
 
 class Auth(auth.BaseAuth):
 
-    def login(self, login: str, password: str) -> str:
+    def _login(self, login: str, password: str) -> str:
         if login == "tmp":
             return login
         return ""


### PR DESCRIPTION
Child classes of BaseAuth must overload _login method not login, otherwise overloading break functionality of {lc,uc}_username 