### PR TITLE
add optional cache for login result and htpasswd + fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12.3', '3.13.0', pypy-3.9]
+        python-version: ['3.9', '3.10', '3.11', '3.12.3', '3.13.0', pypy-3.9]
         exclude:
-          - os: windows-latest
-            python-version: pypy-3.8
           - os: windows-latest
             python-version: pypy-3.9
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## 3.3.4.dev
-* Add: option [auth] cache_logins/cache_logins_expiry for caching successful logins
-* Improve: log used hash method on debug for htpasswd authentication
+* Add: option [auth] cache_logins/cache_successful_logins_expiry/cache_failed_logins for caching logins
+* Improve: log used hash method and result on debug for htpasswd authentication
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.3.4.dev
 * Add: option [auth] cache_logins/cache_successful_logins_expiry/cache_failed_logins for caching logins
 * Improve: log used hash method and result on debug for htpasswd authentication
+* Improve: htpasswd file now read and verified on start, automatic re-read triggered on change (mtime or size)
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add: option [auth] htpasswd_cache to automatic re-read triggered on change (mtime or size) instead reading on each request
 * Improve: [auth] htpasswd: module 'bcrypt' is no longer mandatory in case digest method not used in file
 * Improve: [auth] successful/failed login logs now type and whether result was taken from cache
+* Improve: [auth] constant execution time for failed logins independent of external backend or by htpasswd used digest method
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 3.3.4.dev
+* Add: option [auth] cache_logins/cache_logins_expiry for caching successful logins
+* Improve: log used hash method on debug for htpasswd authentication
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Improve: [auth] htpasswd: module 'bcrypt' is no longer mandatory in case digest method not used in file
 * Improve: [auth] successful/failed login logs now type and whether result was taken from cache
 * Improve: [auth] constant execution time for failed logins independent of external backend or by htpasswd used digest method
+* Drop: support for Python 3.8
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 3.3.4.dev
 * Add: option [auth] cache_logins/cache_successful_logins_expiry/cache_failed_logins for caching logins
 * Improve: [auth] log used hash method and result on debug for htpasswd authentication
-* Improve: [auth] htpasswd file now read and verified on start, automatic re-read triggered on change (mtime or size)
+* Improve: [auth] htpasswd file now read and verified on start
+* Add: option [auth] htpasswd_cache to automatic re-read triggered on change (mtime or size) instead reading on each request
 * Improve: [auth] htpasswd: module 'bcrypt' is no longer mandatory in case digest method not used in file
+* Improve: [auth] successful/failed login logs now type and whether result was taken from cache
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 3.3.4.dev
 * Add: option [auth] cache_logins/cache_successful_logins_expiry/cache_failed_logins for caching logins
-* Improve: log used hash method and result on debug for htpasswd authentication
-* Improve: htpasswd file now read and verified on start, automatic re-read triggered on change (mtime or size)
+* Improve: [auth] log used hash method and result on debug for htpasswd authentication
+* Improve: [auth] htpasswd file now read and verified on start, automatic re-read triggered on change (mtime or size)
+* Improve: [auth] htpasswd: module 'bcrypt' is no longer mandatory in case digest method not used in file
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -812,6 +812,18 @@ Available backends:
 
 Default: `none`
 
+##### cache_logins
+
+Cache successful logins until expiration time
+
+Default: `false`
+
+##### cache_logins_expiry
+
+Expiration time of caching successful logins in seconds
+
+Default: `5`
+
 ##### htpasswd_filename
 
 Path to the htpasswd file.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -872,6 +872,12 @@ Available methods:
 
 Default: `autodetect`
 
+##### htpasswd_cache
+
+Enable caching of htpasswd file based on size and mtime_ns
+
+Default: `False`
+
 ##### delay
 
 Average delay after failed login attempts in seconds.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -814,7 +814,8 @@ Default: `none`
 
 ##### cache_logins
 
-Cache successful/failed logins until expiration time
+Cache successful/failed logins until expiration time. Enable this to avoid
+overload of authentication backends.
 
 Default: `false`
 
@@ -822,13 +823,13 @@ Default: `false`
 
 Expiration time of caching successful logins in seconds
 
-Default: `5`
+Default: `15`
 
 ##### cache_failed_logins_expiry
 
 Expiration time of caching failed logins in seconds
 
-Default: `60`
+Default: `90`
 
 ##### htpasswd_filename
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -814,15 +814,21 @@ Default: `none`
 
 ##### cache_logins
 
-Cache successful logins until expiration time
+Cache successful/failed logins until expiration time
 
 Default: `false`
 
-##### cache_logins_expiry
+##### cache_successful_logins_expiry
 
 Expiration time of caching successful logins in seconds
 
 Default: `5`
+
+##### cache_failed_logins_expiry
+
+Expiration time of caching failed logins in seconds
+
+Default: `60`
 
 ##### htpasswd_filename
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -55,7 +55,7 @@ Follow one of the chapters below depending on your operating system.
 
 #### Linux / \*BSD
 
-First, make sure that **python** 3.8 or later and **pip** are installed. On most distributions it should be
+First, make sure that **python** 3.9 or later and **pip** are installed. On most distributions it should be
 enough to install the package ``python3-pip``.
 
 Then open a console and type:

--- a/config
+++ b/config
@@ -62,11 +62,14 @@
 # Value: none | htpasswd | remote_user | http_x_remote_user | ldap | denyall
 #type = none
 
-# Cache successful logins for until expiration time
+# Cache logins for until expiration time
 #cache_logins = false
 
 # Expiration time for caching successful logins in seconds
-#cache_logins_expiry = 5
+#cache_successful_logins_expiry = 15
+
+## Expiration time of caching failed logins in seconds
+#cache_failed_logins_expiry = 90
 
 # URI to the LDAP server
 #ldap_uri = ldap://localhost

--- a/config
+++ b/config
@@ -109,6 +109,9 @@
 # bcrypt requires the installation of 'bcrypt' module.
 #htpasswd_encryption = autodetect
 
+# Enable caching of htpasswd file based on size and mtime_ns
+#htpasswd_cache = False
+
 # Incorrect authentication delay (seconds)
 #delay = 1
 

--- a/config
+++ b/config
@@ -62,6 +62,12 @@
 # Value: none | htpasswd | remote_user | http_x_remote_user | ldap | denyall
 #type = none
 
+# Cache successful logins for until expiration time
+#cache_logins = false
+
+# Expiration time for caching successful logins in seconds
+#cache_logins_expiry = 5
+
 # URI to the LDAP server
 #ldap_uri = ldap://localhost
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License (GPL)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -28,7 +27,7 @@ classifiers = [
     "Topic :: Office/Business :: Groupware",
 ]
 urls = {Homepage = "https://radicale.org/"}
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dependencies = [
     "defusedxml",
     "passlib",

--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -3,7 +3,7 @@
 # Copyright © 2008 Pascal Halter
 # Copyright © 2008-2017 Guillaume Ayoub
 # Copyright © 2017-2019 Unrud <unrud@outlook.com>
-# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
+# Copyright © 2024-2025 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -252,7 +252,7 @@ class Application(ApplicationPartDelete, ApplicationPartHead,
                 self.configuration, environ, base64.b64decode(
                     authorization.encode("ascii"))).split(":", 1)
 
-        user = self._auth.login(login, password) or "" if login else ""
+        (user, info) = self._auth.login(login, password) or ("", "") if login else ("", "")
         if self.configuration.get("auth", "type") == "ldap":
             try:
                 logger.debug("Groups %r", ",".join(self._auth._ldap_groups))
@@ -260,12 +260,12 @@ class Application(ApplicationPartDelete, ApplicationPartHead,
             except AttributeError:
                 pass
         if user and login == user:
-            logger.info("Successful login: %r", user)
+            logger.info("Successful login: %r (%s)", user, info)
         elif user:
-            logger.info("Successful login: %r -> %r", login, user)
+            logger.info("Successful login: %r -> %r (%s)", login, user, info)
         elif login:
-            logger.warning("Failed login attempt from %s: %r",
-                           remote_host, login)
+            logger.warning("Failed login attempt from %s: %r (%s)",
+                           remote_host, login, info)
             # Random delay to avoid timing oracles and bruteforce attacks
             if self._auth_delay > 0:
                 random_delay = self._auth_delay * (0.5 + random.random())

--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -269,7 +269,7 @@ class Application(ApplicationPartDelete, ApplicationPartHead,
             # Random delay to avoid timing oracles and bruteforce attacks
             if self._auth_delay > 0:
                 random_delay = self._auth_delay * (0.5 + random.random())
-                logger.debug("Sleeping %.3f seconds", random_delay)
+                logger.debug("Failed login, sleeping random: %.3f sec", random_delay)
                 time.sleep(random_delay)
 
         if user and not pathutils.is_safe_path_component(user):

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -91,6 +91,7 @@ class BaseAuth:
         self._auth_delay = configuration.get("auth", "delay")
         logger.info("auth.delay: %f", self._auth_delay)
         self._failed_auth_delay = 0
+        self._lock = threading.Lock()
         # cache_successful_logins
         self._cache_logins = configuration.get("auth", "cache_logins")
         self._type = configuration.get("auth", "type")
@@ -112,7 +113,6 @@ class BaseAuth:
             self._cache_successful = dict()
             self._cache_failed = dict()
             self._cache_failed_logins_salt_ns = time.time_ns()
-            self._lock = threading.Lock()
 
     def _cache_digest(self, login: str, password: str, salt: str) -> str:
         h = hashlib.sha3_512()
@@ -147,7 +147,7 @@ class BaseAuth:
 
         raise NotImplementedError
 
-    def _sleep_for_constant_exec_time(self, time_ns_begin):
+    def _sleep_for_constant_exec_time(self, time_ns_begin: int):
         """Sleep some time to reach a constant execution time for failed logins
 
         Independent of time required by external backend or used digest methods

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -96,7 +96,7 @@ class BaseAuth:
         h.update(salt.encode())
         h.update(login.encode())
         h.update(password.encode())
-        return h.digest()
+        return str(h.digest())
 
     def get_external_login(self, environ: types.WSGIEnviron) -> Union[
             Tuple[()], Tuple[str, str]]:
@@ -155,8 +155,8 @@ class BaseAuth:
                 digest = self._cache_digest(login, password, str(time_ns))
             if result == "":
                 result = self._login(login, password)
-                if result is not "":
-                    if digest is "":
+                if result != "":
+                    if digest == "":
                         # successful login, but expired, digest must be recalculated
                         digest = self._cache_digest(login, password, str(time_ns))
                     # store successful login in cache

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -30,8 +30,8 @@ Take a look at the class ``BaseAuth`` if you want to implement your own.
 """
 
 import hashlib
-import time
 import threading
+import time
 from typing import Sequence, Set, Tuple, Union, final
 
 from radicale import config, types, utils
@@ -89,7 +89,7 @@ class BaseAuth:
         # cache_successful_logins
         self._cache_logins = configuration.get("auth", "cache_logins")
         self._type = configuration.get("auth", "type")
-        if (self._type in [ "dovecot", "ldap", "htpasswd" ]) or (self._cache_logins is False):
+        if (self._type in ["dovecot", "ldap", "htpasswd"]) or (self._cache_logins is False):
             logger.info("auth.cache_logins: %s", self._cache_logins)
         else:
             logger.info("auth.cache_logins: %s (but not required for type '%s' and disabled therefore)", self._cache_logins, self._type)

--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -3,7 +3,7 @@
 # Copyright © 2008 Pascal Halter
 # Copyright © 2008-2017 Guillaume Ayoub
 # Copyright © 2017-2022 Unrud <unrud@outlook.com>
-# Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
+# Copyright © 2024-2025 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -252,13 +252,6 @@ class Auth(auth.BaseAuth):
         Optional: the content of the file is cached and live updates will be detected by
         comparing mtime_ns and size
 
-        TODO: improve against timing attacks
-            see also issue 591
-        but also do not delay that much
-            see also issue 1466
-
-        As several hash methods are supported which have different speed a time based gap would be required
-
         """
         login_ok = False
         digest: str
@@ -299,7 +292,5 @@ class Auth(auth.BaseAuth):
             else:
                 logger.debug("Login verification failed for user: '%s' ( method '%s')", login, method)
         else:
-            # dummy delay
-            (method, password_ok) = self._plain(str(time.time_ns()), password)
             logger.debug("Login verification user not found: '%s'", login)
         return ""

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -3,7 +3,7 @@
 # Copyright © 2008 Pascal Halter
 # Copyright © 2008-2017 Guillaume Ayoub
 # Copyright © 2017-2019 Unrud <unrud@outlook.com>
-# Copyright © 2024 Peter Bieringer <pb@bieringer.de>
+# Copyright © 2024-2025 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -78,7 +78,9 @@ class Auth(auth.BaseAuth):
     def __init__(self, configuration: config.Configuration) -> None:
         super().__init__(configuration)
         self._filename = configuration.get("auth", "htpasswd_filename")
+        logger.info("auth htpasswd file: %r", self._filename)
         self._encoding = configuration.get("encoding", "stock")
+        logger.info("auth htpasswd file encoding: %r", self._encoding)
         self._htpasswd_cache = configuration.get("auth", "htpasswd_cache")
         logger.info("auth htpasswd cache: %s", self._htpasswd_cache)
         encryption: str = configuration.get("auth", "htpasswd_encryption")

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -282,5 +282,7 @@ class Auth(auth.BaseAuth):
             else:
                 logger.debug("Login verification failed for user: '%s' ( method '%s')", login, method)
         else:
+            # dummy delay
+            (method, password_ok) = self._plain(str(htpasswd_mtime_ns), password)
             logger.debug("Login verification user not found: '%s'", login)
         return ""

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -155,6 +155,8 @@ class Auth(auth.BaseAuth):
                             if login_ok and password_ok:
                                 logger.debug("Password verification for user '%s' with method '%s': password_ok=%s", login, method, password_ok)
                                 return login
+                            elif login_ok:
+                                logger.debug("Password verification for user '%s' with method '%s': password_ok=%s", login, method, password_ok)
                         except ValueError as e:
                             raise RuntimeError("Invalid htpasswd file %r: %s" %
                                                (self._filename, e)) from e

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -157,7 +157,7 @@ class Auth(auth.BaseAuth):
             # assumed plaintext
             return self._plain(hash_value, password)
 
-    def _read_htpasswd(self, init: bool, suppress: bool) -> Tuple[bool, int, dict]:
+    def _read_htpasswd(self, init: bool, suppress: bool) -> Tuple[bool, int, dict, int, int]:
         """Read htpasswd file
 
         init == True: stop on error

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -94,23 +94,23 @@ class Auth(auth.BaseAuth):
             raise RuntimeError("The htpasswd encryption method %r is not "
                                "supported." % encryption)
 
-    def _plain(self, hash_value: str, password: str) -> bool:
+    def _plain(self, hash_value: str, password: str) -> tuple[str, bool]:
         """Check if ``hash_value`` and ``password`` match, plain method."""
         return ("PLAIN", hmac.compare_digest(hash_value.encode(), password.encode()))
 
-    def _bcrypt(self, bcrypt: Any, hash_value: str, password: str) -> bool:
+    def _bcrypt(self, bcrypt: Any, hash_value: str, password: str) -> tuple[str, bool]:
         return ("BCRYPT", bcrypt.checkpw(password=password.encode('utf-8'), hashed_password=hash_value.encode()))
 
-    def _md5apr1(self, hash_value: str, password: str) -> bool:
+    def _md5apr1(self, hash_value: str, password: str) -> tuple[str, bool]:
         return ("MD5-APR1", apr_md5_crypt.verify(password, hash_value.strip()))
 
-    def _sha256(self, hash_value: str, password: str) -> bool:
+    def _sha256(self, hash_value: str, password: str) -> tuple[str, bool]:
         return ("SHA-256", sha256_crypt.verify(password, hash_value.strip()))
 
-    def _sha512(self, hash_value: str, password: str) -> bool:
+    def _sha512(self, hash_value: str, password: str) -> tuple[str, bool]:
         return ("SHA-512", sha512_crypt.verify(password, hash_value.strip()))
 
-    def _autodetect(self, hash_value: str, password: str) -> bool:
+    def _autodetect(self, hash_value: str, password: str) -> tuple[str, bool]:
         if hash_value.startswith("$apr1$", 0, 6) and len(hash_value) == 37:
             # MD5-APR1
             return self._md5apr1(hash_value, password)

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -113,7 +113,7 @@ class Auth(auth.BaseAuth):
                     if self._htpasswd_bcrypt_use == 0:
                         logger.info("auth htpasswd encryption is 'radicale.auth.htpasswd_encryption.%s' and bycrypt module found, but currently not required", encryption)
                     else:
-                        logger.info("auth htpasswd encryption is 'radicale.auth.htpasswd_encryption.%s' and bycrypt module found (entries found: %d)", encryption, self._htpasswd_bcrypt_use)
+                        logger.info("auth htpasswd encryption is 'radicale.auth.htpasswd_encryption.%s' and bycrypt module found (bcrypt entries found: %d)", encryption, self._htpasswd_bcrypt_use)
             if encryption == "bcrypt":
                 self._verify = functools.partial(self._bcrypt, bcrypt)
             else:

--- a/radicale/auth/htpasswd.py
+++ b/radicale/auth/htpasswd.py
@@ -283,6 +283,6 @@ class Auth(auth.BaseAuth):
                 logger.debug("Login verification failed for user: '%s' ( method '%s')", login, method)
         else:
             # dummy delay
-            (method, password_ok) = self._plain(str(htpasswd_mtime_ns), password)
+            (method, password_ok) = self._plain(str(time.time_ns()), password)
             logger.debug("Login verification user not found: '%s'", login)
         return ""

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -185,11 +185,15 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "internal": auth.INTERNAL_TYPES}),
         ("cache_logins", {
             "value": "false",
-            "help": "cache successful logins for until expiration time",
+            "help": "cache successful/failed logins for until expiration time",
             "type": bool}),
-        ("cache_logins_expiry", {
+        ("cache_successful_logins_expiry", {
             "value": "5",
             "help": "expiration time for caching successful logins in seconds",
+            "type": int}),
+        ("cache_failed_logins_expiry", {
+            "value": "60",
+            "help": "expiration time for caching failed logins in seconds",
             "type": int}),
         ("htpasswd_filename", {
             "value": "/etc/radicale/users",

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -203,6 +203,10 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "autodetect",
             "help": "htpasswd encryption method",
             "type": str}),
+        ("htpasswd_cache", {
+            "value": "False",
+            "help": "enable caching of htpasswd file",
+            "type": bool}),
         ("dovecot_socket", {
             "value": "/var/run/dovecot/auth-client",
             "help": "dovecot auth socket",

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -183,6 +183,14 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "help": "authentication method",
             "type": str_or_callable,
             "internal": auth.INTERNAL_TYPES}),
+        ("cache_logins", {
+            "value": "false",
+            "help": "cache successful logins for until expiration time",
+            "type": bool}),
+        ("cache_logins_expiry", {
+            "value": "5",
+            "help": "expiration time for caching successful logins in seconds",
+            "type": int}),
         ("htpasswd_filename", {
             "value": "/etc/radicale/users",
             "help": "htpasswd filename",

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -188,11 +188,11 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "help": "cache successful/failed logins for until expiration time",
             "type": bool}),
         ("cache_successful_logins_expiry", {
-            "value": "5",
+            "value": "15",
             "help": "expiration time for caching successful logins in seconds",
             "type": int}),
         ("cache_failed_logins_expiry", {
-            "value": "60",
+            "value": "90",
             "help": "expiration time for caching failed logins in seconds",
             "type": int}),
         ("htpasswd_filename", {

--- a/radicale/tests/test_auth.py
+++ b/radicale/tests/test_auth.py
@@ -23,12 +23,12 @@ Radicale tests with simple requests and authentication.
 """
 
 import base64
+import logging
 import os
 import sys
 from typing import Iterable, Tuple, Union
 
 import pytest
-import logging
 
 from radicale import xmlutils
 from radicale.tests import BaseTest
@@ -139,7 +139,7 @@ class TestBaseAuthRequests(BaseTest):
 
     # detection of broken htpasswd file entries
     def test_htpasswd_broken(self) -> None:
-        for userpass in ["tmp:", ":tmp" ]:
+        for userpass in ["tmp:", ":tmp"]:
             try:
                 self._test_htpasswd("plain", userpass)
             except RuntimeError:

--- a/setup.py.legacy
+++ b/setup.py.legacy
@@ -61,7 +61,7 @@ setup(
     install_requires=install_requires,
     extras_require={"test": test_requires, "bcrypt": bcrypt_requires, "ldap": ldap_requires},
     keywords=["calendar", "addressbook", "CalDAV", "CardDAV"],
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -71,7 +71,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
* Add: option [auth] cache_logins/cache_successful_logins_expiry/cache_failed_logins for caching logins
* Add: option [auth] htpasswd_cache to automatic re-read triggered on change (mtime or size) instead reading on each request
* Improve: [auth] log used hash method and result on debug for htpasswd authentication
* Improve: [auth] htpasswd file now read and verified on start
* Improve: [auth] htpasswd: module 'bcrypt' is no longer mandatory in case digest method not used in file
* Improve: [auth] successful/failed login logs now type and whether result was taken from cache
* Improve: [auth] constant execution time for failed logins independent of external backend or by htpasswd used digest method
* Drop: support for Python 3.8

This should
- improvements for https://github.com/Kozea/Radicale/issues/591 as constant execution time on failed logins is now implemented and now also covering increased time consumption of external backends like dovecot and ldap implicity
- fix https://github.com/Kozea/Radicale/issues/1466 (assume already independent of enabled htpasswd caching)
- support https://github.com/Kozea/Radicale/issues/1639 (if login result cache is enabled)

Unfortunatly, this PR turned bigger and bigger somehow during development :-(