### PR TITLE
More LDAP auth patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Improve: [auth] constant execution time for failed logins independent of external backend or by htpasswd used digest method
 * Drop: support for Python 3.8
 * Add: option [auth] ldap_user_attribute
+* Add: option [auth] ldap_groups_attribute as a more flexible replacement of removed ldap_load_groups
 
 ## 3.3.3
 * Add: display mtime_ns precision of storage folder with condition warning if too less

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -941,6 +941,12 @@ Load the ldap groups of the authenticated user. These groups can be used later o
 
 Default: False
 
+##### ldap_groups_attribute
+
+The LDAP attribute to read the group memberships from in the user's LDAP entry if `ldap_load_groups` is True.
+
+Default: `memberOf`
+
 ##### ldap_use_ssl
 
 Use ssl on the ldap connection

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -926,26 +926,26 @@ The search filter to find the user DN to authenticate by the username. User '{0}
 
 Default: `(cn={0})`
 
-#### ldap_user_attribute
+##### ldap_user_attribute
 
 The LDAP attribute whose value shall be used as the user name after successful authentication
 
 Default: not set, i.e. the login name given is used directly.
 
-##### ldap_load_groups
-
-Load the ldap groups of the authenticated user. These groups can be used later on to define rights. This also gives you access to the group calendars, if they exist.
-* The group calendar will be placed under collection_root_folder/GROUPS
-* The name of the calendar directory is the base64 encoded group name.
-* The group calendar folders will not be created automaticaly. This must be created manually. [Here](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create group calendar folders https://github.com/Kozea/Radicale/wiki/LDAP-authentication
-
-Default: False
-
 ##### ldap_groups_attribute
 
-The LDAP attribute to read the group memberships from in the user's LDAP entry if `ldap_load_groups` is True.
+The LDAP attribute to read the group memberships from in the authenticated user's LDAP entry.
 
-Default: `memberOf`
+If set, load the LDAP group memberships from the attribute given
+These memberships can be used later on to define rights.
+This also gives you access to the group calendars, if they exist.
+* The group calendar will be placed under collection_root_folder/GROUPS
+* The name of the calendar directory is the base64 encoded group name.
+* The group calendar folders will not be created automatically. This must be done manually. In the [LDAP-authentication section of Radicale's wiki](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create a group calendar.
+
+Use 'memberOf' if you want to load groups on Active Directory and alikes, 'groupMembership' on Novell eDirectory, ...
+
+Default: unset
 
 ##### ldap_use_ssl
 

--- a/config
+++ b/config
@@ -89,6 +89,9 @@
 # If the ldap groups of the user need to be loaded
 #ldap_load_groups = True
 
+# the attribute to read the group memberships from in the user's LDAP entry if ldap_load_groups is True.
+#ldap_groups_attribute = memberOf
+
 # The filter to find the DN of the user. This filter must contain a python-style placeholder for the login
 #ldap_filter = (&(objectClass=person)(uid={0}))
 

--- a/config
+++ b/config
@@ -86,10 +86,7 @@
 # Path of the file containing password of the reader DN
 #ldap_secret_file = /run/secrets/ldap_password
 
-# If the ldap groups of the user need to be loaded
-#ldap_load_groups = True
-
-# the attribute to read the group memberships from in the user's LDAP entry if ldap_load_groups is True.
+# the attribute to read the group memberships from in the user's LDAP entry (default: not set)
 #ldap_groups_attribute = memberOf
 
 # The filter to find the DN of the user. This filter must contain a python-style placeholder for the login

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -160,8 +160,11 @@ class Auth(auth.BaseAuth):
                 tmp = []
                 for g in user_entry[1][self._ldap_groups_attr]:
                     """Get group g's RDN's attribute value"""
-                    g = g.decode('utf-8').split(',')[0]
-                    tmp.append(g.partition('=')[2])
+                    try:
+                        rdns = self.ldap.dn.explode_dn(g, notypes=True)
+                        tmp.append(rdns[0])
+                    except Exception:
+                        tmp.append(g.decode('utf8'))
                 self._ldap_groups = set(tmp)
                 logger.debug("_login2 LDAP groups of user: %s", ",".join(self._ldap_groups))
             if self._ldap_user_attr:
@@ -230,8 +233,11 @@ class Auth(auth.BaseAuth):
                 tmp = []
                 for g in user_entry['attributes'][self._ldap_groups_attr]:
                     """Get group g's RDN's attribute value"""
-                    g = g.split(',')[0]
-                    tmp.append(g.partition('=')[2])
+                    try:
+                        rdns = self.ldap3.utils.dn.parse_dn(g)
+                        tmp.append(rdns[0][1])
+                    except Exception:
+                        tmp.append(g)
                 self._ldap_groups = set(tmp)
                 logger.debug("_login3 LDAP groups of user: %s", ",".join(self._ldap_groups))
             if self._ldap_user_attr:

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -43,7 +43,7 @@ class Auth(auth.BaseAuth):
     _ldap_reader_dn: str
     _ldap_secret: str
     _ldap_filter: str
-    _ldap_attributes: list[str] = ['memberOf']
+    _ldap_attributes: list[str] = []
     _ldap_user_attr: str
     _ldap_load_groups: bool
     _ldap_module_version: int = 3
@@ -111,6 +111,8 @@ class Auth(auth.BaseAuth):
             else:
                 logger.info("auth.ldap_ssl_ca_file     : (not provided)")
         """Extend attributes to to be returned in the user query"""
+        if self._ldap_load_groups:
+            self._ldap_attributes.append('memberOf')
         if self._ldap_user_attr:
             self._ldap_attributes.append(self._ldap_user_attr)
         logger.info("ldap_attributes           : %r" % self._ldap_attributes)

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -251,6 +251,10 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "False",
             "help": "load the ldap groups of the authenticated user",
             "type": bool}),
+        ("ldap_groups_attribute", {
+            "value": "memberOf",
+            "help": "attribute to read the group memberships from",
+            "type": str}),
         ("ldap_use_ssl", {
             "value": "False",
             "help": "Use ssl on the ldap connection",

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -247,12 +247,8 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "",
             "help": "the attribute to be used as username after authentication",
             "type": str}),
-        ("ldap_load_groups", {
-            "value": "False",
-            "help": "load the ldap groups of the authenticated user",
-            "type": bool}),
         ("ldap_groups_attribute", {
-            "value": "memberOf",
+            "value": "",
             "help": "attribute to read the group memberships from",
             "type": str}),
         ("ldap_use_ssl", {


### PR DESCRIPTION
Hi,

here's another round of LDAP auth patches
They deal with issues not dealt with in the previous round:
* avoid code duplication by calculating attributes to query in `__init__()`
* allow using LDAP authentication also to servers that do not know the `memberOf` attribute
  by querying it only if `ldap_load_groups` is `True`
* introduce config option `ldap_groups_attribute` that allows us to configure the groups attribute name
  instead of having it being hard coded to `memberOf`
* get rid of `ldap_load_groups` config option. - having `ldap_groups_attribute` being unset
  resp. being set to a specific attribute name has the exact same effect
* stop fiddling around with getting the RDN value of the groups attributes returned, 
  and instead use the LDAP modules' helper functions foreseen for this purpose.
  In addition, this gives us a bit more flexibility with the `ldap_groups_attribute`: we can use attribute with non-DN syntax too.
  As radicale does not rely on on the DN syntax, but only takes the RDN value anyway, this is no limitation, but a real extension
  
  Please consider incorporating them into mainline radicale