### PR TITLE
Fix incorrect method override in authentication plugin example

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1819,7 +1819,7 @@ class Auth(BaseAuth):
     def __init__(self, configuration):
         super().__init__(configuration.copy(PLUGIN_CONFIG_SCHEMA))
 
-    def login(self, login, password):
+    def _login(self, login, password):
         # Get password from configuration option
         static_password = self.configuration.get("auth", "password")
         # Check authentication


### PR DESCRIPTION
The documentation originally instructed overriding login() when implementing a custom authentication plugin. However, BaseAuth.login() performs additional preprocessing before calling _login(), which is the method intended for authentication logic.

Overriding login() directly causes a 'Too many values to unpack' error during a PROPFIND request, as login() is expected to return multiple values in a tuple. This PR updates the example to correctly override _login() instead.

Reference: [BaseAuth.login() marked as final and calls _login()](https://github.com/raguilar127/Radicale/blob/c2def71ce660e0972190294368ce47f2212113ee/radicale/auth/__init__.py#L190)
