### PR TITLE
Use AUTHENTICATE PLAIN instead of LOGIN

### DIFF
--- a/radicale/auth/imap.py
+++ b/radicale/auth/imap.py
@@ -59,7 +59,10 @@ class Auth(auth.BaseAuth):
                 if self._security == "starttls":
                     connection.starttls(ssl.create_default_context())
             try:
-                connection.login(login, password)
+                connection.authenticate(
+                    "PLAIN",
+                    lambda _: "{0}\x00{0}\x00{1}".format(login, password).encode(),
+                )
             except imaplib.IMAP4.error as e:
                 logger.warning("IMAP authentication failed for user %r: %s", login, e, exc_info=False)
                 return ""


### PR DESCRIPTION
Makes imaplib use more modern AUTHENTICATE verb
rather than LOGIN.
The immediate benefit is that now the credentials
can be non-ASCII.
In the future, it may be used to add other
authentication methods, such as OAuth.

References:
* https://datatracker.ietf.org/doc/html/rfc6855.html#page-5
* https://bugs.python.org/issue13700

Note: This patch was originally created in 2021 against RadicaleIMAP, which has since been integrated to Radicale. Here is the original discussion: https://github.com/Unrud/RadicaleIMAP/pull/7