### PR TITLE
added configuration to enable radicale LDAP with Authentik

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1060,6 +1060,16 @@ The path to the CA file in pem format which is used to certificate the server ce
 
 Default:
 
+##### ldap_ignore_attribute_create_modify_timestamp
+
+_(>= 3.6.0)_
+
+Add modifyTimestamp and createTimestamp to the exclusion list of internal ldap3 client
+so that these schema attributes are not checked. This is needed for Authentik since
+Authentik does not provide these both attributes.
+
+Default: false
+
 ##### dovecot_connection_type = AF_UNIX
 
 _(>= 3.4.1)_

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1062,7 +1062,7 @@ Default:
 
 ##### ldap_ignore_attribute_create_modify_timestamp
 
-_(>= 3.6.0)_
+_(>= 3.5.1)_
 
 Add modifyTimestamp and createTimestamp to the exclusion list of internal ldap3 client
 so that these schema attributes are not checked. This is needed for Authentik since

--- a/config
+++ b/config
@@ -75,7 +75,7 @@
 #cache_failed_logins_expiry = 90
 
 # Ignore modifyTimestamp and createTimestamp attributes. Needed if Authentik LDAP server is used. Uncomment then.
-#ldap_authentik_timestamp_hack = true  
+#ldap_ignore_attribute_create_modify_timestamp = true  
 
 # URI to the LDAP server
 #ldap_uri = ldap://localhost

--- a/config
+++ b/config
@@ -74,6 +74,9 @@
 ## Expiration time of caching failed logins in seconds
 #cache_failed_logins_expiry = 90
 
+# Ignore modifyTimestamp and createTimestamp attributes. Needed if Authentik LDAP server is used. Uncomment then.
+#ldap_authentik_timestamp_hack = true  
+
 # URI to the LDAP server
 #ldap_uri = ldap://localhost
 

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -65,8 +65,8 @@ class Auth(auth.BaseAuth):
             except ImportError as e:
                 raise RuntimeError("LDAP authentication requires the ldap3 module") from e
        
-        self._ldap_authentik_timestamp_hack = configuration.get("auth", "ldap_authentik_timestamp_hack")
-        if self._ldap_authentik_timestamp_hack:
+        self._ldap_ignore_attribute_create_modify_timestamp = configuration.get("auth", "ldap_ignore_attribute_create_modify_timestamp")
+        if self._ldap_ignore_attribute_create_modify_timestamp:
            self.ldap3.utils.config._ATTRIBUTES_EXCLUDED_FROM_CHECK.extend(['createTimestamp','modifyTimestamp'])
            logger.info("auth.ldap_authentik_timestamp_hack applied")
 

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -63,11 +63,11 @@ class Auth(auth.BaseAuth):
                 self.ldap = ldap
             except ImportError as e:
                 raise RuntimeError("LDAP authentication requires the ldap3 module") from e
-       
+
         self._ldap_ignore_attribute_create_modify_timestamp = configuration.get("auth", "ldap_ignore_attribute_create_modify_timestamp")
         if self._ldap_ignore_attribute_create_modify_timestamp:
-           self.ldap3.utils.config._ATTRIBUTES_EXCLUDED_FROM_CHECK.extend(['createTimestamp','modifyTimestamp'])
-           logger.info("auth.ldap_ignore_attribute_create_modify_timestamp applied")
+            self.ldap3.utils.config._ATTRIBUTES_EXCLUDED_FROM_CHECK.extend(['createTimestamp', 'modifyTimestamp'])
+            logger.info("auth.ldap_ignore_attribute_create_modify_timestamp applied")
 
         self._ldap_uri = configuration.get("auth", "ldap_uri")
         self._ldap_base = configuration.get("auth", "ldap_base")

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -56,7 +56,6 @@ class Auth(auth.BaseAuth):
         try:
             import ldap3
             self.ldap3 = ldap3
- 
         except ImportError:
             try:
                 import ldap

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -68,7 +68,7 @@ class Auth(auth.BaseAuth):
         self._ldap_ignore_attribute_create_modify_timestamp = configuration.get("auth", "ldap_ignore_attribute_create_modify_timestamp")
         if self._ldap_ignore_attribute_create_modify_timestamp:
            self.ldap3.utils.config._ATTRIBUTES_EXCLUDED_FROM_CHECK.extend(['createTimestamp','modifyTimestamp'])
-           logger.info("auth.ldap_authentik_timestamp_hack applied")
+           logger.info("auth.ldap_ignore_attribute_create_modify_timestamp applied")
 
         self._ldap_uri = configuration.get("auth", "ldap_uri")
         self._ldap_base = configuration.get("auth", "ldap_base")

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -56,6 +56,7 @@ class Auth(auth.BaseAuth):
         try:
             import ldap3
             self.ldap3 = ldap3
+ 
         except ImportError:
             try:
                 import ldap
@@ -63,6 +64,12 @@ class Auth(auth.BaseAuth):
                 self.ldap = ldap
             except ImportError as e:
                 raise RuntimeError("LDAP authentication requires the ldap3 module") from e
+       
+        self._ldap_authentik_timestamp_hack = configuration.get("auth", "ldap_authentik_timestamp_hack")
+        if self._ldap_authentik_timestamp_hack:
+           self.ldap3.utils.config._ATTRIBUTES_EXCLUDED_FROM_CHECK.extend(['createTimestamp','modifyTimestamp'])
+           logger.info("auth.ldap_authentik_timestamp_hack applied")
+
         self._ldap_uri = configuration.get("auth", "ldap_uri")
         self._ldap_base = configuration.get("auth", "ldap_base")
         self._ldap_reader_dn = configuration.get("auth", "ldap_reader_dn")

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -259,9 +259,9 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "1",
             "help": "incorrect authentication delay",
             "type": positive_float}),
-        ("ldap_authentik_timestamp_hack", {
+        ("ldap_ignore_attribute_create_modify_timestamp", {
             "value": "false",
-            "help": "Ignore modifyTimestamp and createTimestamp attributes. Need if Authentik LDAP server is used",
+            "help": "Ignore modifyTimestamp and createTimestamp attributes. Need if Authentik LDAP server is used.",
             "type": bool}),
         ("ldap_uri", {
             "value": "ldap://localhost",

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -213,7 +213,7 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
         ("cache_logins", {
             "value": "false",
             "help": "cache successful/failed logins for until expiration time",
-            "type": bool}),      
+            "type": bool}),
         ("cache_successful_logins_expiry", {
             "value": "15",
             "help": "expiration time for caching successful logins in seconds",

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -213,7 +213,7 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
         ("cache_logins", {
             "value": "false",
             "help": "cache successful/failed logins for until expiration time",
-            "type": bool}),
+            "type": bool}),      
         ("cache_successful_logins_expiry", {
             "value": "15",
             "help": "expiration time for caching successful logins in seconds",
@@ -259,6 +259,10 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "1",
             "help": "incorrect authentication delay",
             "type": positive_float}),
+        ("ldap_authentik_timestamp_hack", {
+            "value": "false",
+            "help": "Ignore modifyTimestamp and createTimestamp attributes. Need if Authentik LDAP server is used",
+            "type": bool}),
         ("ldap_uri", {
             "value": "ldap://localhost",
             "help": "URI to the ldap server",


### PR DESCRIPTION
added a configuration option to exclulde check of modifyTimestamp and createTimestamp within ldap3 to allow working with Authentik (which doies not include these schema attributes)