### PR TITLE
Update ldap.py

### DIFF
--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -242,7 +242,7 @@ class Auth(auth.BaseAuth):
                 logger.debug("_login3 LDAP groups of user: %s", ",".join(self._ldap_groups))
             if self._ldap_user_attr:
                 if user_entry['attributes'][self._ldap_user_attr]:
-                    login = user_entry['attributes'][self._ldap_user_attr][0]
+                    login = user_entry['attributes'][self._ldap_user_attr]
                     logger.debug(f"_login3 user set to: '{login}'")
             conn.unbind()
             logger.debug(f"_login3 {login} successfully authenticated")


### PR DESCRIPTION
Bugfix, user_entry['attributes'][self._ldap_user_attr] is already the string so user_entry['attributes'][self._ldap_user_attr][0] would give only the first character and not the full user attribute