### PR TITLE
fix(auth/ldap): Extract user attribute from list in _login3

### DIFF
--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -248,7 +248,10 @@ class Auth(auth.BaseAuth):
                 logger.debug("_login3 LDAP groups of user: %s", ",".join(self._ldap_groups))
             if self._ldap_user_attr:
                 if user_entry['attributes'][self._ldap_user_attr]:
-                    login = user_entry['attributes'][self._ldap_user_attr]
+                    if isinstance(user_entry['attributes'][self._ldap_user_attr], list):
+                        login = user_entry['attributes'][self._ldap_user_attr][0]
+                    else:
+                        login = user_entry['attributes'][self._ldap_user_attr]
                     logger.debug(f"_login3 user set to: '{login}'")
             conn.unbind()
             logger.debug(f"_login3 {login} successfully authenticated")


### PR DESCRIPTION
This commit modifies `_login3` to check if the attribute value is a list and, if so, extracts the first element (`[0]`) as the login identifier. If the value is not a list, it's used directly (fallback).

Error log:
```
[2025-04-17 13:49:14 +0800] [7/Thread-4 (process_request_thread)] [INFO] Successful login: 'miles' -> ['miles'] (ldap)
[2025-04-17 13:49:14 +0800] [7/Thread-4 (process_request_thread)] [WARNING] Access to principal path "/['miles']/" denied by rights backend
[2025-04-17 13:49:14 +0800] [7/Thread-4 (process_request_thread)] [INFO] PROPFIND response status for '/' in 0.146 seconds: 207 Multi-Status
[2025-04-17 13:49:14 +0800] [7/Thread-5 (process_request_thread)] [INFO] PROPFIND request for "/['miles']/" with depth '1' received from 172.18.0.14 (forwarded for '112.104.28.234') using 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
[2025-04-17 13:49:14 +0800] [7/Thread-5 (process_request_thread)] [WARNING] Called by reverse proxy, cannot removed base prefix '/dav' from path: "/['miles']/" as not matching
[2025-04-17 13:49:14 +0800] [7/Thread-5 (process_request_thread)] [INFO] Access to "/['miles']/" denied for anonymous user
[2025-04-17 13:49:14 +0800] [7/Thread-5 (process_request_thread)] [INFO] PROPFIND response status for "/['miles']/" with depth '1' in 0.001 seconds: 401 Unauthorized
[2025-04-17 13:49:14 +0800] [7/Thread-6 (process_request_thread)] [INFO] PROPFIND request for "/['miles']/" with depth '1' received from 172.18.0.14 (forwarded for '112.104.28.234') using 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
[2025-04-17 13:49:14 +0800] [7/Thread-6 (process_request_thread)] [WARNING] Called by reverse proxy, cannot removed base prefix '/dav' from path: "/['miles']/" as not matching
```