### PR TITLE
Fix an issue when iOS clients send email as username url-encoded.

### DIFF
--- a/radicale/config.py
+++ b/radicale/config.py
@@ -342,6 +342,10 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
         ("lc_username", {
             "value": "False",
             "help": "convert username to lowercase, must be true for case-insensitive auth providers",
+            "type": bool}),
+        ("urldecode_username", {
+            "value": "False",
+            "help": "url-decode the username, set to True when clients send url-encoded email address as username",
             "type": bool})])),
     ("rights", OrderedDict([
         ("type", {


### PR DESCRIPTION
When the username is an email address, the iOS calendar sends it URL encoded for authentication.  In my case authentication is happening against imap, so it breaks authentication for those clients.  By adding the option to url-decode the username, the server works for iOS devices.

Proposing a configuration in auth caller urldecode_username to control this feature.
