### PR TITLE
Docker publish workflow: Add scheduled and workflow_dispatch triggers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,9 @@ name: Build and publish Docker image
 on:
   release:
     types: [published]
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -31,8 +34,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=true
           tags: |
             type=semver,pattern={{version}}
+            type=schedule,prefix=nightly-,pattern={{date 'YYYYMMDD'}}
+            type=raw,enable=${{ github.event_name == 'workflow_dispatch' }},value=workflow_dispatch-{{branch}}-{{sha}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Details

* In addition to the existing triggers, add:
    * scheduled trigger 
        * At - 00:00 UTC daily. 
        * Docker image tag - `nightly-YYYYMMDD`.
        * Naming convention: The prefix `nightly-` is added to differentiate docker images created by different triggers.
    * workflow dispatch trigger
    	* For triggering workflow manually.
    	* Docker image tag: `workflow_dispatch-<git branch>-<latest commit sha>`.
    	* Naming convention: 
    	    * The prefix `workflow_dispatch-` is added to differentiate docker images created by different triggers.
    	    * `<git branch>` is added to the name because the workflow dispatch trigger can be done on any branch. Presence of a branch name helps to differentiate between other `workflow_dispatch` triggers.
    	    * `<latest commit sha>` is added to differentiate between docker images created by this workflow if it is triggered for different commits in the same branch.
* `latest` tag will also be added for both the above cases.


## Future improvement

Skip the scheduled trigger if there are no new commits