### PR TITLE
Docker publish workflow: Add architecture linux/arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,14 @@ jobs:
             type=schedule,prefix=nightly-,pattern={{date 'YYYYMMDD'}}
             type=raw,enable=${{ github.event_name == 'workflow_dispatch' }},value=workflow_dispatch-{{branch}}-{{sha}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -47,3 +55,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
From the listed future tasks in https://github.com/Kozea/Radicale/discussions/1745#discussioncomment-13004594

> Add support for other architectures (e.g. arm64)


This PR adds support for arm64. Other architectures can be added later if needed.