### PR TITLE
Docker publish workflow: Install optional pip dependencies

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,6 +52,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          build-args: DEPENDENCIES=bcrypt,argon2,ldap
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
* Dependencies taken from `pyproject.toml`
* As of now, following are added:
    * bcrypt
    * argon2 
    * ldap

This is as per the request in https://github.com/Kozea/Radicale/discussions/1745#discussioncomment-13337452