### PR TITLE
Guard against entries with no vevent_list in the vobject

### DIFF
--- a/radicale/app/report.py
+++ b/radicale/app/report.py
@@ -310,7 +310,8 @@ def xml_report(base_prefix: str, path: str, xml_request: Optional[ET.Element],
                     found_props.append(expanded_element)
                 else:
                     found_props.append(element)
-                    n_vevents += len(item.vobject_item.vevent_list)
+                    if hasattr(item.vobject_item, "vevent_list"):
+                        n_vevents += len(item.vobject_item.vevent_list)
                 # Avoid DoS with too many events
                 if max_occurrence and n_vevents > max_occurrence:
                     raise ValueError("REPORT occurrences limit of {} hit"


### PR DESCRIPTION
The error for #1820 came from a  line added as part of the anti-DoS code to count vevents in #1812

vobject attributes are created dynamically and there appears to be no vevent_list in the user's data.

This is likely because the prop.tag is CR:address-data.

Instead of checking item.component_name == 'VEVENT' be safe and check the attr we actually are looking at: vevent_list