### PR TITLE
Improve email notification hook by determining event update type

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1630,11 +1630,11 @@ When enabled, send one email to all attendee email addresses. When disabled, sen
 
 Default: `False`
 
-##### added_template
+##### new_or_added_to_event_template
 
 _(>= 3.5.5)_
 
-Template to use for added/updated event email body.
+Template to use for added/updated event email body (sent to an attendee when the event is created or they are added to a pre-existing event).
 
 The following placeholders will be replaced:
 - `$organizer_name`: Name of the organizer, or "Unknown Organizer" if not set in event
@@ -1660,11 +1660,11 @@ You have been added as an attendee to the following calendar event.
 This is an automated message. Please do not reply.
 ```
 
-##### removed_template
+##### deleted_or_removed_from_event_template
 
 _(>= 3.5.5)_
 
-Template to use for deleted event email body.
+Template to use for deleted/removed event email body (sent to an attendee when the event is deleted or they are removed from the event).
 
 The following placeholders will be replaced:
 - `$organizer_name`: Name of the organizer, or "Unknown Organizer" if not set in event
@@ -1681,12 +1681,44 @@ Default:
 ```
 Hello $attendee_name,
 
-You have been removed as an attendee from the following calendar event.
+The following event has been deleted.
 
     $event_title
     $event_start_time - $event_end_time
     $event_location
 
+This is an automated message. Please do not reply.
+```
+
+#### updated_event_template
+
+_(>= 3.5.5)_
+
+Template to use for updated event email body (sent to an attendee when non-attendee-related details of the event are updated).
+
+Existing attendees will NOT be notified of a modified event if the only changes are adding/removing other attendees.
+
+The following placeholders will be replaced:
+- `$organizer_name`: Name of the organizer, or "Unknown Organizer" if not set in event
+- `$from_email`: Email address the email is sent from
+- `$attendee_name`: Name of the attendee (email recipient), or "everyone" if mass email enabled.
+- `$event_name`: Name/summary of the event, or "No Title" if not set in event
+- `$event_start_time`: Start time of the event in ISO 8601 format
+- `$event_end_time`: End time of the event in ISO 8601 format, or "No End Time" if the event has no end time
+- `$event_location`: Location of the event, or "No Location Specified" if not set in event
+
+Providing any words prefixed with $ not included in the list above will result in an error.
+
+Default: 
+```
+Hello $attendee_name,
+            
+The following event has been updated.
+
+    $event_title
+    $event_start_time - $event_end_time
+    $event_location
+    
 This is an automated message. Please do not reply.
 ```
 

--- a/config
+++ b/config
@@ -334,6 +334,9 @@
 #smtp_password =
 #from_email =
 #mass_email = False
+#new_or_added_to_event_template =
+#deleted_or_removed_from_event_template =
+#updated_event_template =
 
 
 [reporting]

--- a/radicale/app/__init__.py
+++ b/radicale/app/__init__.py
@@ -323,7 +323,7 @@ class Application(ApplicationPartDelete, ApplicationPartHead,
                 if "W" in self._rights.authorization(user, principal_path):
                     with self._storage.acquire_lock("w", user):
                         try:
-                            new_coll = self._storage.create_collection(principal_path)
+                            new_coll, _, _ = self._storage.create_collection(principal_path)
                             if new_coll:
                                 jsn_coll = self.configuration.get("storage", "predefined_collections")
                                 for (name_coll, props) in jsn_coll.items():

--- a/radicale/app/delete.py
+++ b/radicale/app/delete.py
@@ -85,6 +85,7 @@ class ApplicationPartDelete(ApplicationBase):
                         HookNotificationItem(
                             notification_item_type=HookNotificationItemTypes.DELETE,
                             path=access.path,
+                            content=i.uid,
                             uid=i.uid,
                             old_content=item.serialize(),  # type: ignore
                             new_content=None
@@ -98,6 +99,7 @@ class ApplicationPartDelete(ApplicationBase):
                     HookNotificationItem(
                         notification_item_type=HookNotificationItemTypes.DELETE,
                         path=access.path,
+                        content=item.uid,
                         uid=item.uid,
                         old_content=item.serialize(),  # type: ignore
                         new_content=None,

--- a/radicale/app/delete.py
+++ b/radicale/app/delete.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 from radicale import httputils, storage, types, xmlutils
 from radicale.app.base import Access, ApplicationBase
-from radicale.hook import DeleteHookNotificationItem
+from radicale.hook import HookNotificationItem, HookNotificationItemTypes
 from radicale.log import logger
 
 
@@ -82,10 +82,12 @@ class ApplicationPartDelete(ApplicationBase):
                         return httputils.NOT_ALLOWED
                 for i in item.get_all():
                     hook_notification_item_list.append(
-                        DeleteHookNotificationItem(
-                            access.path,
-                            i.uid,
-                            old_content=item.serialize()  # type: ignore
+                        HookNotificationItem(
+                            notification_item_type=HookNotificationItemTypes.DELETE,
+                            path=access.path,
+                            uid=i.uid,
+                            old_content=item.serialize(),  # type: ignore
+                            new_content=None
                         )
                     )
                 xml_answer = xml_delete(base_prefix, path, item)
@@ -93,10 +95,12 @@ class ApplicationPartDelete(ApplicationBase):
                 assert item.collection is not None
                 assert item.href is not None
                 hook_notification_item_list.append(
-                    DeleteHookNotificationItem(
-                        access.path,
-                        item.uid,
-                        old_content=item.serialize()  # type: ignore
+                    HookNotificationItem(
+                        notification_item_type=HookNotificationItemTypes.DELETE,
+                        path=access.path,
+                        uid=item.uid,
+                        old_content=item.serialize(),  # type: ignore
+                        new_content=None,
                     )
                 )
                 xml_answer = xml_delete(

--- a/radicale/app/proppatch.py
+++ b/radicale/app/proppatch.py
@@ -101,13 +101,17 @@ class ApplicationPartProppatch(ApplicationBase):
                 xml_answer = xml_proppatch(base_prefix, path, xml_content,
                                            item)
                 if xml_content is not None:
+                    content = DefusedET.tostring(
+                        xml_content,
+                        encoding=self._encoding
+                    ).decode(encoding=self._encoding)
                     hook_notification_item = HookNotificationItem(
                         notification_item_type=HookNotificationItemTypes.CPATCH,
                         path=access.path,
-                        new_content=DefusedET.tostring(
-                            xml_content,
-                            encoding=self._encoding
-                        ).decode(encoding=self._encoding)
+                        content=content,
+                        uid=None,
+                        old_content=None,
+                        new_content=content
                     )
                     self._hook.notify(hook_notification_item)
             except ValueError as e:

--- a/radicale/app/proppatch.py
+++ b/radicale/app/proppatch.py
@@ -102,9 +102,9 @@ class ApplicationPartProppatch(ApplicationBase):
                                            item)
                 if xml_content is not None:
                     hook_notification_item = HookNotificationItem(
-                        HookNotificationItemTypes.CPATCH,
-                        access.path,
-                        DefusedET.tostring(
+                        notification_item_type=HookNotificationItemTypes.CPATCH,
+                        path=access.path,
+                        new_content=DefusedET.tostring(
                             xml_content,
                             encoding=self._encoding
                         ).decode(encoding=self._encoding)

--- a/radicale/app/put.py
+++ b/radicale/app/put.py
@@ -249,7 +249,7 @@ class ApplicationPartPut(ApplicationBase):
                         props=props)
                     for item in prepared_items:
                         # Try to grab the previously-existing item by href
-                        existing_item = replaced_items.get(item.href, None)
+                        existing_item = replaced_items.get(item.href, None)  # type: ignore
                         if existing_item:
                             hook_notification_item = HookNotificationItem(
                                 notification_item_type=HookNotificationItemTypes.UPSERT,

--- a/radicale/app/put.py
+++ b/radicale/app/put.py
@@ -243,14 +243,27 @@ class ApplicationPartPut(ApplicationBase):
 
             if write_whole_collection:
                 try:
-                    etag = self._storage.create_collection(
-                        path, prepared_items, props).etag
+                    col, replaced_items, new_item_hrefs = self._storage.create_collection(
+                        href=path,
+                        items=prepared_items,
+                        props=props)
                     for item in prepared_items:
-                        hook_notification_item = HookNotificationItem(
-                            HookNotificationItemTypes.UPSERT,
-                            access.path,
-                            item.serialize()
-                        )
+                        # Try to grab the previously-existing item by href
+                        existing_item = replaced_items.get(item.href, None)
+                        if existing_item:
+                            hook_notification_item = HookNotificationItem(
+                                notification_item_type=HookNotificationItemTypes.UPSERT,
+                                path=access.path,
+                                old_content=existing_item.serialize(),
+                                new_content=item.serialize()
+                            )
+                        else:  # We assume the item is new because it was not in the replaced_items
+                            hook_notification_item = HookNotificationItem(
+                                notification_item_type=HookNotificationItemTypes.UPSERT,
+                                path=access.path,
+                                old_content=None,
+                                new_content=item.serialize()
+                            )
                         self._hook.notify(hook_notification_item)
                 except ValueError as e:
                     logger.warning(
@@ -267,12 +280,23 @@ class ApplicationPartPut(ApplicationBase):
 
                 href = posixpath.basename(pathutils.strip_path(path))
                 try:
-                    etag = parent_item.upload(href, prepared_item).etag
-                    hook_notification_item = HookNotificationItem(
-                        HookNotificationItemTypes.UPSERT,
-                        access.path,
-                        prepared_item.serialize()
-                    )
+                    uploaded_item, replaced_item = parent_item.upload(href, prepared_item)
+                    etag = uploaded_item.etag
+                    if replaced_item:
+                        # If the item was replaced, we notify with the old content
+                        hook_notification_item = HookNotificationItem(
+                            notification_item_type=HookNotificationItemTypes.UPSERT,
+                            path=access.path,
+                            old_content=replaced_item.serialize(),
+                            new_content=prepared_item.serialize()
+                        )
+                    else:  # If it was a new item, we notify with no old content
+                        hook_notification_item = HookNotificationItem(
+                            notification_item_type=HookNotificationItemTypes.UPSERT,
+                            path=access.path,
+                            old_content=None,
+                            new_content=prepared_item.serialize()
+                        )
                     self._hook.notify(hook_notification_item)
                 except ValueError as e:
                     # return better matching HTTP result in case errno is provided and catched

--- a/radicale/app/put.py
+++ b/radicale/app/put.py
@@ -254,6 +254,8 @@ class ApplicationPartPut(ApplicationBase):
                             hook_notification_item = HookNotificationItem(
                                 notification_item_type=HookNotificationItemTypes.UPSERT,
                                 path=access.path,
+                                content=existing_item.serialize(),
+                                uid=None,
                                 old_content=existing_item.serialize(),
                                 new_content=item.serialize()
                             )
@@ -261,6 +263,8 @@ class ApplicationPartPut(ApplicationBase):
                             hook_notification_item = HookNotificationItem(
                                 notification_item_type=HookNotificationItemTypes.UPSERT,
                                 path=access.path,
+                                content=item.serialize(),
+                                uid=None,
                                 old_content=None,
                                 new_content=item.serialize()
                             )
@@ -282,21 +286,14 @@ class ApplicationPartPut(ApplicationBase):
                 try:
                     uploaded_item, replaced_item = parent_item.upload(href, prepared_item)
                     etag = uploaded_item.etag
-                    if replaced_item:
-                        # If the item was replaced, we notify with the old content
-                        hook_notification_item = HookNotificationItem(
-                            notification_item_type=HookNotificationItemTypes.UPSERT,
-                            path=access.path,
-                            old_content=replaced_item.serialize(),
-                            new_content=prepared_item.serialize()
-                        )
-                    else:  # If it was a new item, we notify with no old content
-                        hook_notification_item = HookNotificationItem(
-                            notification_item_type=HookNotificationItemTypes.UPSERT,
-                            path=access.path,
-                            old_content=None,
-                            new_content=prepared_item.serialize()
-                        )
+                    hook_notification_item = HookNotificationItem(
+                        notification_item_type=HookNotificationItemTypes.UPSERT,
+                        path=access.path,
+                        content=prepared_item.serialize(),
+                        uid=None,
+                        old_content=replaced_item.serialize() if replaced_item else None,
+                        new_content=prepared_item.serialize()
+                    )
                     self._hook.notify(hook_notification_item)
                 except ValueError as e:
                     # return better matching HTTP result in case errno is provided and catched

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -477,7 +477,7 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "False",
             "help": "Send one email to all attendees, versus one email per attendee",
             "type": bool}),
-        ("added_template", {
+        ("new_or_added_to_event_template", {
             "value": """Hello $attendee_name,
 
 You have been added as an attendee to the following calendar event.
@@ -487,20 +487,31 @@ You have been added as an attendee to the following calendar event.
     $event_location
 
 This is an automated message. Please do not reply.""",
-            "help": "Template for the email sent when an event is added or updated. Select placeholder words prefixed with $ will be replaced",
+            "help": "Template for the email sent when an event is created or attendee is added. Select placeholder words prefixed with $ will be replaced",
             "type": str}),
-        ("removed_template", {
+        ("deleted_or_removed_from_event_template", {
             "value": """Hello $attendee_name,
 
-You have been removed as an attendee from the following calendar event.
+The following event has been deleted.
 
     $event_title
     $event_start_time - $event_end_time
     $event_location
 
 This is an automated message. Please do not reply.""",
-            "help": "Template for the email sent when an event is deleted. Select placeholder words prefixed with $ will be replaced",
+            "help": "Template for the email sent when an event is deleted or attendee is removed. Select placeholder words prefixed with $ will be replaced",
             "type": str}),
+        ("updated_event_template", {
+            "value": """Hello $attendee_name,
+The following event has been updated.
+    $event_title
+    $event_start_time - $event_end_time
+    $event_location
+    
+This is an automated message. Please do not reply.""",
+            "help": "Template for the email sent when an event is updated. Select placeholder words prefixed with $ will be replaced",
+            "type": str
+        })
     ])),
     ("web", OrderedDict([
         ("type", {

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -507,7 +507,7 @@ The following event has been updated.
     $event_title
     $event_start_time - $event_end_time
     $event_location
-    
+
 This is an automated message. Please do not reply.""",
             "help": "Template for the email sent when an event is updated. Select placeholder words prefixed with $ will be replaced",
             "type": str

--- a/radicale/hook/__init__.py
+++ b/radicale/hook/__init__.py
@@ -55,10 +55,21 @@ def _cleanup(path):
 
 class HookNotificationItem:
 
-    def __init__(self, notification_item_type, path, content):
+    def __init__(self, notification_item_type, path, uid=None, new_content=None, old_content=None):
         self.type = notification_item_type.value
         self.point = _cleanup(path)
-        self.content = content
+        self.uid = uid
+        self.new_content = new_content
+        self.old_content = old_content
+
+    @property
+    def content(self):  # For backward compatibility
+        return self.uid or self.new_content or self.old_content
+
+    @property
+    def replaces_existing_item(self) -> bool:
+        """Check if this notification item replaces/deletes an existing item."""
+        return self.old_content is not None
 
     def to_json(self):
         return json.dumps(
@@ -67,9 +78,3 @@ class HookNotificationItem:
             sort_keys=True,
             indent=4
         )
-
-
-class DeleteHookNotificationItem(HookNotificationItem):
-    def __init__(self, path, uid, old_content=None):
-        super().__init__(notification_item_type=HookNotificationItemTypes.DELETE, path=path, content=uid)
-        self.old_content = old_content

--- a/radicale/hook/__init__.py
+++ b/radicale/hook/__init__.py
@@ -55,16 +55,17 @@ def _cleanup(path):
 
 class HookNotificationItem:
 
-    def __init__(self, notification_item_type, path, uid=None, new_content=None, old_content=None):
+    def __init__(self, notification_item_type, path, content=None, uid=None, new_content=None, old_content=None):
         self.type = notification_item_type.value
         self.point = _cleanup(path)
+        self._content_legacy = content
         self.uid = uid
         self.new_content = new_content
         self.old_content = old_content
 
     @property
     def content(self):  # For backward compatibility
-        return self.uid or self.new_content or self.old_content
+        return self._content_legacy or self.uid or self.new_content or self.old_content
 
     @property
     def replaces_existing_item(self) -> bool:
@@ -73,8 +74,7 @@ class HookNotificationItem:
 
     def to_json(self):
         return json.dumps(
-            self,
-            default=lambda o: o.__dict__,
+            {**self.__dict__, "content": self.content},
             sort_keys=True,
             indent=4
         )

--- a/radicale/hook/email/__init__.py
+++ b/radicale/hook/email/__init__.py
@@ -981,10 +981,13 @@ class Hook(BaseHook):
                 return
             email_event_end_time = email_event_event.datetime_end  # type: ignore
             # Skip notification if the event end time is more than 1 minute in the past.
-            if email_event_end_time and email_event_end_time.time and email_event_end_time.time < (
-                    datetime.now() - timedelta(minutes=1)):
-                logger.warning("Event end time is in the past, skipping notification for event: %s",
-                               email_event_event.uid)
+            if email_event_end_time and email_event_end_time.time:
+                event_end = email_event_end_time.time  # type: ignore
+                now = datetime.now(
+                    event_end.tzinfo) if event_end.tzinfo else datetime.now()  # Handle timezone-aware datetime
+                if event_end < (now - timedelta(minutes=1)):
+                    logger.warning("Event end time is in the past, skipping notification for event: %s",
+                                   email_event_event.uid)
                 return
 
             if not previous_item_str:

--- a/radicale/hook/email/__init__.py
+++ b/radicale/hook/email/__init__.py
@@ -946,7 +946,7 @@ class Hook(BaseHook):
         :type notification_item: HookNotificationItem
         :return: None
         """
-        if self.dryrun:
+        if self.email_config.dryrun:
             logger.warning("Hook 'email': DRY-RUN received notification_item: %r", vars(notification_item))
         else:
             logger.debug("Received notification_item: %r", vars(notification_item))

--- a/radicale/hook/email/__init__.py
+++ b/radicale/hook/email/__init__.py
@@ -91,13 +91,13 @@ This is an automated message. Please do not reply.""",
         },
         "updated_event_template": {
             "value": """Hello $attendee_name,
-            
+
 The following event has been updated.
 
     $event_title
     $event_start_time - $event_end_time
     $event_location
-    
+
 This is an automated message. Please do not reply.""",
             "type": str
         },

--- a/radicale/hook/email/__init__.py
+++ b/radicale/hook/email/__init__.py
@@ -31,7 +31,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import vobject
 
-from radicale.hook import (BaseHook, HookNotificationItem, HookNotificationItemTypes)
+from radicale.hook import (BaseHook, HookNotificationItem,
+                           HookNotificationItemTypes)
 from radicale.log import logger
 
 PLUGIN_CONFIG_SCHEMA = {
@@ -985,7 +986,7 @@ class Hook(BaseHook):
                 return
 
             # Dealing with an update to an existing event, compare new and previous content.
-            new_event: Event = read_ics_event(contents=new_item_str)
+            new_event: Event = read_ics_event(contents=new_item_str)  # type: ignore
             previous_event: Optional[Event] = read_ics_event(contents=previous_item_str)
             if not previous_event:
                 # If we cannot parse the previous event for some reason, simply treat it as a new event.

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -27,8 +27,8 @@ Take a look at the class ``BaseCollection`` if you want to implement your own.
 import json
 import xml.etree.ElementTree as ET
 from hashlib import sha256
-from typing import (Callable, ContextManager, Iterable, Iterator, Mapping,
-                    Optional, Sequence, Set, Tuple, Union, overload, Dict, List)
+from typing import (Callable, ContextManager, Dict, Iterable, Iterator, List,
+                    Mapping, Optional, Sequence, Set, Tuple, Union, overload)
 
 import vobject
 
@@ -44,7 +44,8 @@ INTERNAL_TYPES: Sequence[str] = ("multifilesystem", "multifilesystem_nolock",)
 # NOTE: change only if cache structure is modified to avoid cache invalidation on update
 CACHE_VERSION_RADICALE = "3.3.1"
 
-CACHE_VERSION: bytes = ("%s=%s;%s=%s;" % ("radicale", CACHE_VERSION_RADICALE, "vobject", utils.package_version("vobject"))).encode()
+CACHE_VERSION: bytes = (
+            "%s=%s;%s=%s;" % ("radicale", CACHE_VERSION_RADICALE, "vobject", utils.package_version("vobject"))).encode()
 
 
 def load(configuration: "config.Configuration") -> "BaseStorage":
@@ -112,17 +113,18 @@ class BaseCollection:
                  invalid.
 
         """
+
         def hrefs_iter() -> Iterator[str]:
             for item in self.get_all():
                 assert item.href
                 yield item.href
+
         token = "http://radicale.org/ns/sync/%s" % self.etag.strip("\"")
         if old_token:
             raise ValueError("Sync token are not supported")
         return token, hrefs_iter()
 
-    def get_multi(self, hrefs: Iterable[str]
-                  ) -> Iterable[Tuple[str, Optional["radicale_item.Item"]]]:
+    def get_multi(self, hrefs: Iterable[str]) -> Iterable[Tuple[str, Optional["radicale_item.Item"]]]:
         """Fetch multiple items.
 
         It's not required to return the requested items in the correct order.
@@ -175,7 +177,7 @@ class BaseCollection:
         return False
 
     def upload(self, href: str, item: "radicale_item.Item") -> (
-            "radicale_item.Item", Optional["radicale_item.Item"]):
+            Tuple)["radicale_item.Item", Optional["radicale_item.Item"]]:
         """Upload a new or replace an existing item.
 
         Return the uploaded item and the old item if it was replaced.
@@ -191,10 +193,12 @@ class BaseCollection:
         raise NotImplementedError
 
     @overload
-    def get_meta(self, key: None = None) -> Mapping[str, str]: ...
+    def get_meta(self, key: None = None) -> Mapping[str, str]:
+        ...
 
     @overload
-    def get_meta(self, key: str) -> Optional[str]: ...
+    def get_meta(self, key: str) -> Optional[str]:
+        ...
 
     def get_meta(self, key: Optional[str] = None
                  ) -> Union[Mapping[str, str], Optional[str]]:
@@ -297,7 +301,7 @@ class BaseStorage:
     def discover(
             self, path: str, depth: str = "0",
             child_context_manager: Optional[
-            Callable[[str, Optional[str]], ContextManager[None]]] = None,
+                Callable[[str, Optional[str]], ContextManager[None]]] = None,
             user_groups: Set[str] = set([])) -> Iterable["types.CollectionOrItem"]:
         """Discover a list of collections under the given ``path``.
 

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -28,7 +28,7 @@ import json
 import xml.etree.ElementTree as ET
 from hashlib import sha256
 from typing import (Callable, ContextManager, Iterable, Iterator, Mapping,
-                    Optional, Sequence, Set, Tuple, Union, overload)
+                    Optional, Sequence, Set, Tuple, Union, overload, Dict, List)
 
 import vobject
 
@@ -175,8 +175,11 @@ class BaseCollection:
         return False
 
     def upload(self, href: str, item: "radicale_item.Item") -> (
-            "radicale_item.Item"):
-        """Upload a new or replace an existing item."""
+            "radicale_item.Item", Optional["radicale_item.Item"]):
+        """Upload a new or replace an existing item.
+
+        Return the uploaded item and the old item if it was replaced.
+        """
         raise NotImplementedError
 
     def delete(self, href: Optional[str] = None) -> None:
@@ -328,7 +331,8 @@ class BaseStorage:
     def create_collection(
             self, href: str,
             items: Optional[Iterable["radicale_item.Item"]] = None,
-            props: Optional[Mapping[str, str]] = None) -> BaseCollection:
+            props: Optional[Mapping[str, str]] = None) -> (
+            Tuple)[BaseCollection, Dict[str, "radicale_item.Item"], List[str]]:
         """Create a collection.
 
         ``href`` is the sanitized path.

--- a/radicale/storage/__init__.py
+++ b/radicale/storage/__init__.py
@@ -300,8 +300,7 @@ class BaseStorage:
 
     def discover(
             self, path: str, depth: str = "0",
-            child_context_manager: Optional[
-                Callable[[str, Optional[str]], ContextManager[None]]] = None,
+            child_context_manager: Optional[Callable[[str, Optional[str]], ContextManager[None]]] = None,
             user_groups: Set[str] = set([])) -> Iterable["types.CollectionOrItem"]:
         """Discover a list of collections under the given ``path``.
 

--- a/radicale/storage/multifilesystem/create_collection.py
+++ b/radicale/storage/multifilesystem/create_collection.py
@@ -19,7 +19,7 @@
 
 import os
 from tempfile import TemporaryDirectory
-from typing import Iterable, Optional, cast, List, Tuple, Dict
+from typing import Dict, Iterable, List, Optional, Tuple, cast
 
 import radicale.item as radicale_item
 from radicale import pathutils

--- a/radicale/storage/multifilesystem/create_collection.py
+++ b/radicale/storage/multifilesystem/create_collection.py
@@ -19,7 +19,7 @@
 
 import os
 from tempfile import TemporaryDirectory
-from typing import Iterable, Optional, cast
+from typing import Iterable, Optional, cast, List, Tuple, Dict
 
 import radicale.item as radicale_item
 from radicale import pathutils
@@ -30,9 +30,37 @@ from radicale.storage.multifilesystem.base import StorageBase
 
 class StoragePartCreateCollection(StorageBase):
 
+    def _discover_existing_items_pre_overwrite(self,
+                                               tmp_collection: "multifilesystem.Collection",
+                                               dst_path: str) -> Tuple[Dict[str, radicale_item.Item], List[str]]:
+        """Discover existing items in the collection before overwriting them."""
+        existing_items = {}
+        new_item_hrefs = []
+
+        existing_collection = self._collection_class(
+            cast(multifilesystem.Storage, self),
+            pathutils.unstrip_path(dst_path, True))
+        existing_item_hrefs = set(existing_collection._list())
+        tmp_collection_hrefs = set(tmp_collection._list())
+        for item_href in tmp_collection_hrefs:
+            if item_href not in existing_item_hrefs:
+                # Item in temporary collection does not exist in the existing collection (is new)
+                new_item_hrefs.append(item_href)
+                continue
+            # Item exists in both collections, grab the existing item for reference
+            try:
+                item = existing_collection._get(item_href, verify_href=False)
+                if item is not None:
+                    existing_items[item_href] = item
+            except Exception:
+                # TODO: Log exception?
+                continue
+
+        return existing_items, new_item_hrefs
+
     def create_collection(self, href: str,
                           items: Optional[Iterable[radicale_item.Item]] = None,
-                          props=None) -> "multifilesystem.Collection":
+                          props=None) -> Tuple["multifilesystem.Collection", Dict[str, radicale_item.Item], List[str]]:
         folder = self._get_collection_root_folder()
 
         # Path should already be sanitized
@@ -44,10 +72,13 @@ class StoragePartCreateCollection(StorageBase):
             self._makedirs_synced(filesystem_path)
             return self._collection_class(
                 cast(multifilesystem.Storage, self),
-                pathutils.unstrip_path(sane_path, True))
+                pathutils.unstrip_path(sane_path, True)), {}, []
 
         parent_dir = os.path.dirname(filesystem_path)
         self._makedirs_synced(parent_dir)
+
+        replaced_items: Dict[str, radicale_item.Item] = {}
+        new_item_hrefs: List[str] = []
 
         # Create a temporary directory with an unsafe name
         try:
@@ -68,14 +99,20 @@ class StoragePartCreateCollection(StorageBase):
                         col._upload_all_nonatomic(items, suffix=".vcf")
 
                 if os.path.lexists(filesystem_path):
+                    replaced_items, new_item_hrefs = self._discover_existing_items_pre_overwrite(
+                        tmp_collection=col,
+                        dst_path=sane_path)
                     pathutils.rename_exchange(tmp_filesystem_path, filesystem_path)
                 else:
+                    # If the destination path does not exist, obviously all items are new
+                    new_item_hrefs = list(col._list())
                     os.rename(tmp_filesystem_path, filesystem_path)
                 self._sync_directory(parent_dir)
         except Exception as e:
             raise ValueError("Failed to create collection %r as %r %s" %
                              (href, filesystem_path, e)) from e
 
+        # TODO: Return new-old pairs and just-new items (new vs updated)
         return self._collection_class(
             cast(multifilesystem.Storage, self),
-            pathutils.unstrip_path(sane_path, True))
+            pathutils.unstrip_path(sane_path, True)), replaced_items, new_item_hrefs

--- a/radicale/storage/multifilesystem/upload.py
+++ b/radicale/storage/multifilesystem/upload.py
@@ -21,7 +21,7 @@ import errno
 import os
 import pickle
 import sys
-from typing import Iterable, Iterator, TextIO, cast, Optional, Tuple
+from typing import Iterable, Iterator, Optional, TextIO, Tuple, cast
 
 import radicale.item as radicale_item
 from radicale import pathutils

--- a/radicale/storage/multifilesystem/upload.py
+++ b/radicale/storage/multifilesystem/upload.py
@@ -21,7 +21,7 @@ import errno
 import os
 import pickle
 import sys
-from typing import Iterable, Iterator, TextIO, cast
+from typing import Iterable, Iterator, TextIO, cast, Optional, Tuple
 
 import radicale.item as radicale_item
 from radicale import pathutils
@@ -36,10 +36,11 @@ class CollectionPartUpload(CollectionPartGet, CollectionPartCache,
                            CollectionPartHistory, CollectionBase):
 
     def upload(self, href: str, item: radicale_item.Item
-               ) -> radicale_item.Item:
+               ) -> Tuple[radicale_item.Item, Optional[radicale_item.Item]]:
         if not pathutils.is_safe_filesystem_path_component(href):
             raise pathutils.UnsafePathError(href)
         path = pathutils.path_to_filesystem(self._filesystem_path, href)
+        old_item = self._get(href, verify_href=False)
         try:
             with self._atomic_write(path, newline="") as fo:  # type: ignore
                 f = cast(TextIO, fo)
@@ -67,7 +68,7 @@ class CollectionPartUpload(CollectionPartGet, CollectionPartCache,
         uploaded_item = self._get(href, verify_href=False)
         if uploaded_item is None:
             raise RuntimeError("Storage modified externally")
-        return uploaded_item
+        return uploaded_item, old_item
 
     def _upload_all_nonatomic(self, items: Iterable[radicale_item.Item],
                               suffix: str = "") -> None:

--- a/radicale/tests/test_hook_email.py
+++ b/radicale/tests/test_hook_email.py
@@ -21,6 +21,8 @@ Radicale tests related to hook 'email'
 
 import logging
 import os
+import re
+from datetime import datetime, timedelta
 
 from radicale.tests import BaseTest
 from radicale.tests.helpers import get_file_content
@@ -63,11 +65,26 @@ permissions: RrWw""")
         self.configure({"hook": {"type": "email",
                                  "dryrun": "True"}})
 
-    def test_add_event(self, caplog) -> None:
+    def _future_date_timestamp(self) -> str:
+        """Return a date timestamp for a future date."""
+        future_date = datetime.now() + timedelta(days=1)
+        return future_date.strftime("%Y%m%dT%H%M%S")
+
+    def _past_date_timestamp(self) -> str:
+        past_date = datetime.now() - timedelta(days=1)
+        return past_date.strftime("%Y%m%dT%H%M%S")
+
+    def _replace_end_date_in_event(self, event: str, new_date: str) -> str:
+        """Replace the end date in an event string."""
+        return re.sub(r"DTEND;TZID=Europe/Paris:\d{8}T\d{6}",
+                      f"DTEND;TZID=Europe/Paris:{new_date}", event)
+
+    def test_add_event_with_future_end_date(self, caplog) -> None:
         caplog.set_level(logging.WARNING)
         """Add an event."""
         self.mkcalendar("/calendar.ics/")
         event = get_file_content("event1.ics")
+        event = self._replace_end_date_in_event(event, self._future_date_timestamp())
         path = "/calendar.ics/event1.ics"
         self.put(path, event)
         _, headers, answer = self.request("GET", path, check=200)
@@ -87,11 +104,30 @@ permissions: RrWw""")
         if (found != 7):
             raise ValueError("Logging misses expected log lines, found=%d", found)
 
-    def test_delete_event(self, caplog) -> None:
+    def test_add_event_with_past_end_date(self, caplog) -> None:
+        caplog.set_level(logging.WARNING)
+        """Add an event."""
+        self.mkcalendar("/calendar.ics/")
+        event = get_file_content("event1.ics")
+        event = self._replace_end_date_in_event(event, self._past_date_timestamp())
+        path = "/calendar.ics/event1.ics"
+        self.put(path, event)
+        _, headers, answer = self.request("GET", path, check=200)
+        assert "ETag" in headers
+        assert headers["Content-Type"] == "text/calendar; charset=utf-8"
+        assert "VEVENT" in answer
+        assert "Event" in answer
+        assert "UID:event" in answer
+
+        # Should not trigger an email
+        assert len(caplog.messages) == 0
+
+    def test_delete_event_with_future_end_date(self, caplog) -> None:
         caplog.set_level(logging.WARNING)
         """Delete an event."""
         self.mkcalendar("/calendar.ics/")
         event = get_file_content("event1.ics")
+        event = self._replace_end_date_in_event(event, self._future_date_timestamp())
         path = "/calendar.ics/event1.ics"
         self.put(path, event)
         _, responses = self.delete(path)
@@ -108,3 +144,19 @@ permissions: RrWw""")
                 found = found | 4
         if (found != 7):
             raise ValueError("Logging misses expected log lines, found=%d", found)
+
+    def test_delete_event_with_past_end_date(self, caplog) -> None:
+        caplog.set_level(logging.WARNING)
+        """Delete an event."""
+        self.mkcalendar("/calendar.ics/")
+        event = get_file_content("event1.ics")
+        event = self._replace_end_date_in_event(event, self._past_date_timestamp())
+        path = "/calendar.ics/event1.ics"
+        self.put(path, event)
+        _, responses = self.delete(path)
+        assert responses[path] == 200
+        _, answer = self.get("/calendar.ics/")
+        assert "VEVENT" not in answer
+
+        # Should not trigger an email
+        assert len(caplog.messages) == 0


### PR DESCRIPTION
Adding to #1808 , this PR introduces additional logic that will determine what type of change was made to an event that triggered the hook, and send out notifications accordingly.

- Event created -> All associated attendees are notified that they were added to an event.
- Some attendees added to existing event -> New attendees are notified that they were added to an event, existing attendees are not notified.
- Some attendees removed from existing event -> Removed attendees are notified that the event was deleted, existing attendees are not notified.
- Event deleted -> All associated attendees are notified that the event was deleted

This PR introduces a pre-save collection of the original event, to allow the email hook to compare the new incoming update against the original version prior to an overwrite save.

This PR also modifies the parameters passed into the `HookNotificationItem` constructor to collect the original/updated event contents. The signature is unmodified in terms of order and required parameters, and the class includes a `content` auto-property to maintain backwards compatibility with existing hook extensions. As a result, this should NOT present a breaking change.