### PR TITLE
Fix - Storage hook only adds path to item in PUT

### DIFF
--- a/radicale/app/delete.py
+++ b/radicale/app/delete.py
@@ -60,7 +60,7 @@ class ApplicationPartDelete(ApplicationBase):
         access = Access(self._rights, user, path)
         if not access.check("w"):
             return httputils.NOT_ALLOWED
-        with self._storage.acquire_lock("w", user):
+        with self._storage.acquire_lock("w", user, path=path):
             item = next(iter(self._storage.discover(path)), None)
             if not item:
                 return httputils.NOT_FOUND

--- a/radicale/app/mkcalendar.py
+++ b/radicale/app/mkcalendar.py
@@ -57,7 +57,7 @@ class ApplicationPartMkcalendar(ApplicationBase):
             return httputils.BAD_REQUEST
         # TODO: use this?
         # timezone = props.get("C:calendar-timezone")
-        with self._storage.acquire_lock("w", user):
+        with self._storage.acquire_lock("w", user, path=path):
             item = next(iter(self._storage.discover(path)), None)
             if item:
                 return self._webdav_error_response(

--- a/radicale/app/mkcol.py
+++ b/radicale/app/mkcol.py
@@ -62,7 +62,7 @@ class ApplicationPartMkcol(ApplicationBase):
         if not props.get("tag") and "W" not in permissions:
             logger.warning("MKCOL request %r (type:%s): %s", path, collection_type, "rejected because of missing rights 'W'")
             return httputils.NOT_ALLOWED
-        with self._storage.acquire_lock("w", user):
+        with self._storage.acquire_lock("w", user, path=path):
             item = next(iter(self._storage.discover(path)), None)
             if item:
                 return httputils.METHOD_NOT_ALLOWED

--- a/radicale/app/move.py
+++ b/radicale/app/move.py
@@ -73,7 +73,7 @@ class ApplicationPartMove(ApplicationBase):
         if not to_access.check("w"):
             return httputils.NOT_ALLOWED
 
-        with self._storage.acquire_lock("w", user):
+        with self._storage.acquire_lock("w", user, path=path):
             item = next(iter(self._storage.discover(path)), None)
             if not item:
                 return httputils.NOT_FOUND

--- a/radicale/app/proppatch.py
+++ b/radicale/app/proppatch.py
@@ -87,7 +87,7 @@ class ApplicationPartProppatch(ApplicationBase):
         except socket.timeout:
             logger.debug("Client timed out", exc_info=True)
             return httputils.REQUEST_TIMEOUT
-        with self._storage.acquire_lock("w", user):
+        with self._storage.acquire_lock("w", user, path=path):
             item = next(iter(self._storage.discover(path)), None)
             if not item:
                 return httputils.NOT_FOUND

--- a/radicale/tests/test_storage.py
+++ b/radicale/tests/test_storage.py
@@ -233,17 +233,17 @@ class TestCustomStorageSystemCallable(BaseTest):
 
 class TestStorageHook(BaseTest):
     """Test the storage hook"""
-    
-    HOOK_STRING="Captured stdout from storage hook:"
-    SANATISED_STRING="Sanitized path:"
-    
-    #TODO: How to give the result of the cmd to the test
+
+    HOOK_STRING = "Captured stdout from storage hook:"
+    SANATISED_STRING = "Sanitized path:"
+
+    # TODO: How to give the result of the cmd to the test
     def setup_method(self) -> None:
         _TestBaseRequests.setup_method(cast(_TestBaseRequests, self))
         cmd = "echo \'{\"user\":\"%(user)s\", \"path\":\"%(path)s\", \"cwd\":\"%(cwd)s\"}\'"
         self.configure({"storage": {"hook": cmd}})
-        
-    def get_output(self, records:list[logging.LogRecord]) -> dict[str, str]:
+
+    def get_output(self, records: list[logging.LogRecord]) -> dict[str, str]:
         """
         Get the result of the storage hook execution
 
@@ -258,17 +258,17 @@ class TestStorageHook(BaseTest):
             # We assume a message looks like such: [date] [thread] [DEBUG] Captured stdout from storage hook: "{user:"", "path":"", "cwd":""}"
             if self.HOOK_STRING not in message:
                 continue
-            print("Message:",message)
+            print("Message:", message)
             _, raw_info = message.split(self.HOOK_STRING)
             raw_info = raw_info.strip("\"")
             try:
                 return json.loads(raw_info)
-            except:
+            except json.JSONDecodeError:
                 # Try and find the next one
                 pass
-        assert "Unable to find storage hook"
+        assert False, "Unable to find storage hook"
 
-    def check_path(self, records: list[logging.LogRecord], path:str):
+    def check_path(self, records: list[logging.LogRecord], path: str):
         result = self.get_output(records)
         assert result["path"].endswith(path), f"{result["path"]} does not end in {path}"
 
@@ -281,11 +281,10 @@ class TestStorageHook(BaseTest):
         caplog.set_level(logging.DEBUG)
         self.put(path, event)
         self.check_path(caplog.records, path)
-        
+
         caplog.set_level(logging.INFO)
-        
-    
-    def test_update_event(self, caplog: pytest.LogCaptureFixture  ) -> None:
+
+    def test_update_event(self, caplog: pytest.LogCaptureFixture) -> None:
         """Update an event."""
         caplog.set_level(logging.INFO)
         self.mkcalendar("/calendar.ics/")
@@ -312,14 +311,16 @@ class TestStorageHook(BaseTest):
 
     def test_mkcalendar(self, caplog: pytest.LogCaptureFixture) -> None:
         """Make a calendar"""
+        path = "/calendar.ics/"
         caplog.set_level(logging.DEBUG)
-        self.mkcalendar("/calendar.ics/")
+        self.mkcalendar(path)
         caplog.set_level(logging.INFO)
-        self.check_path(caplog.records, "/calendar.ics/")
-        
+        self.check_path(caplog.records, path)
+
     def test_mkcol(self, caplog: pytest.LogCaptureFixture) -> None:
         """Make a collection."""
+        path = "/user/"
         caplog.set_level(logging.DEBUG)
-        self.mkcol("/user/")
+        self.mkcol(path)
         caplog.set_level(logging.INFO)
-        self.check_path(caplog.records, "/user/")
+        self.check_path(caplog.records, path)


### PR DESCRIPTION
Fix of issue #1842 - Storage hook only adds path to item in PUT.

- Added path to `self._storage.acquire_lock()` in all files that were missing it.
- Added tests to check the paths given to the hook are correct