### PR TITLE
auth: dovecot: pass rip= to auth server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix: broken start when UID does not exist (potential container startup case)
 * Improve: user/group retrievement for running service and directories
 * Extend/Improve: [auth] ldap: group membership lookup
+* Add: option [auth] dovecot_rip_x_remote_addr
 
 ## 3.5.5
 * Improve: [auth] ldap: do not read server info by bind to avoid needless network traffic

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1187,6 +1187,26 @@ Port of via network exposed dovecot socket
 
 Default: `12345`
 
+##### dovecot_rip_x_remote_addr
+
+_(>= 3.5.6)_
+
+Use the `X-Remote-Addr` value for the remote IP (rip) parameter in the
+dovecot authentication protocol.
+
+If set, Radicale must be running behind a proxy that you control and
+that sets/overwrites the `X-Remote-Addr` header (doesn't pass it) so
+that the value passed to dovecot is reliable. For example, for nginx,
+add
+
+```
+    proxy_set_header  X-Remote-Addr $remote_addr;
+```
+
+to the configuration sample.
+
+Default: `False`
+
 ##### imap_host
 
 _(>= 3.4.1)_

--- a/config
+++ b/config
@@ -136,6 +136,9 @@
 # Port of via network exposed dovecot socket
 #dovecot_port = 12345
 
+# Use X-Remote-Addr for remote IP (rip) in dovecot authentication
+#dovecot_rip_x_remote_addr = False
+
 # IMAP server hostname
 # Syntax: address | address:port | [address]:port | imap.server.tld
 #imap_host = localhost

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -253,6 +253,10 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "12345",
             "help": "dovecot auth port",
             "type": int}),
+        ("dovecot_rip_x_remote_addr", {
+            "value": "False",
+            "help": "use X-Remote-Addr for dovecot auth remote IP (rip) parameter",
+            "type": bool}),
         ("realm", {
             "value": "Radicale - Password Required",
             "help": "message displayed when a password is needed",


### PR DESCRIPTION
If known, let the auth server know where the client came from, using (in this order) forwarded-for or remote-addr.

Addresses #1859.