### PR TITLE
LDAP auth: move evaluation of quirk for Authentik where it belongs

### DIFF
--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -88,10 +88,6 @@ class Auth(auth.BaseAuth):
                 raise RuntimeError("LDAP authentication requires the ldap3 module") from e
 
         self._ldap_ignore_attribute_create_modify_timestamp = configuration.get("auth", "ldap_ignore_attribute_create_modify_timestamp")
-        if self._ldap_ignore_attribute_create_modify_timestamp:
-            self.ldap3.utils.config._ATTRIBUTES_EXCLUDED_FROM_CHECK.extend(['createTimestamp', 'modifyTimestamp'])
-            logger.info("auth.ldap_ignore_attribute_create_modify_timestamp applied")
-
         self._ldap_uri = configuration.get("auth", "ldap_uri")
         self._ldap_base = configuration.get("auth", "ldap_base")
         self._ldap_reader_dn = configuration.get("auth", "ldap_reader_dn")
@@ -259,6 +255,10 @@ class Auth(auth.BaseAuth):
             return ""
 
     def _login3(self, login: str, password: str) -> str:
+        if self._ldap_ignore_attribute_create_modify_timestamp:
+            self.ldap3.utils.config._ATTRIBUTES_EXCLUDED_FROM_CHECK.extend(['createTimestamp', 'modifyTimestamp'])
+            logger.info("auth.ldap_ignore_attribute_create_modify_timestamp applied")
+
         """Connect the server"""
         try:
             logger.debug(f"_login3 {self._ldap_uri}, {self._ldap_reader_dn}")


### PR DESCRIPTION
The evaluation of the quirk for the Authentik LDAP server changes the behaviour of Python's `ldap3` module, and that module only.
Evaluating the quirk in `__init__` which is used for both, `ldap` and `ldap3` is thus wrong, and may lead to errors when this setting is used together with the `ldap` module.