### PR TITLE
Ldap auth overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.5.8.dev
+* Extend [auth]: re-factor & overhaul LDPA autrhentication, especially for Python's ldap module
 
 ## 3.5.7
 * Extend: [auth] dovecot: add support for version >= 2.4

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -119,6 +119,9 @@ class Auth(auth.BaseAuth):
         if self._ldap_uri.lower().startswith("ldaps://") and self._ldap_security not in ("tls", "starttls"):
             logger.info("Inferring 'ldap_security' = tls from 'ldap_uri' starting with 'ldaps://'")
             self._ldap_security = "tls"
+        if self._ldap_uri.lower().startswith("ldapi://") and self._ldap_ssl_verify_mode != "NONE":
+            logger.info("Lowering 'ldap_'ldap_ssl_verify_mode' to NONE for 'ldap_uri' starting with 'ldapi://'")
+            self._ldap_ssl_verify_mode = "NONE"
 
         if self._ldap_ssl_ca_file == "" and self._ldap_ssl_verify_mode != "NONE" and self._ldap_security in ("tls", "starttls"):
             logger.warning("Certificate verification not possible: 'ldap_ssl_ca_file' not set")

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -102,21 +102,19 @@ class Auth(auth.BaseAuth):
         if ldap_secret_file_path:
             with open(ldap_secret_file_path, 'r') as file:
                 self._ldap_secret = file.read().rstrip('\n')
-        if self._ldap_module_version == 3:
-            self._ldap_use_ssl = configuration.get("auth", "ldap_use_ssl")
-            self._ldap_security = configuration.get("auth", "ldap_security")
-            self._use_encryption = self._ldap_use_ssl or self._ldap_security in ("tls", "starttls")
-            if self._ldap_use_ssl and self._ldap_security == "starttls":
-                raise RuntimeError("Cannot set both 'ldap_use_ssl = True' and 'ldap_security' = 'starttls'")
-            if self._ldap_use_ssl:
-                logger.warning("Configuration uses soon to be deprecated 'ldap_use_ssl', use 'ldap_security' ('none', 'tls', 'starttls') instead.")
-            if self._use_encryption:
-                self._ldap_ssl_ca_file = configuration.get("auth", "ldap_ssl_ca_file")
-                tmp = configuration.get("auth", "ldap_ssl_verify_mode")
-                if tmp == "NONE":
-                    self._ldap_ssl_verify_mode = ssl.CERT_NONE
-                elif tmp == "OPTIONAL":
-                    self._ldap_ssl_verify_mode = ssl.CERT_OPTIONAL
+        self._ldap_use_ssl = configuration.get("auth", "ldap_use_ssl")
+        self._ldap_security = configuration.get("auth", "ldap_security")
+        self._use_encryption = self._ldap_use_ssl or self._ldap_security in ("tls", "starttls")
+        if self._ldap_use_ssl and self._ldap_security == "starttls":
+            raise RuntimeError("Cannot set both 'ldap_use_ssl = True' and 'ldap_security' = 'starttls'")
+        if self._ldap_use_ssl:
+            logger.warning("Configuration uses soon to be deprecated 'ldap_use_ssl', use 'ldap_security' ('none', 'tls', 'starttls') instead.")
+        self._ldap_ssl_ca_file = configuration.get("auth", "ldap_ssl_ca_file")
+        tmp = configuration.get("auth", "ldap_ssl_verify_mode")
+        if tmp == "NONE":
+            self._ldap_ssl_verify_mode = ssl.CERT_NONE
+        elif tmp == "OPTIONAL":
+            self._ldap_ssl_verify_mode = ssl.CERT_OPTIONAL
 
         logger.info("auth.ldap_uri             : %r" % self._ldap_uri)
         logger.info("auth.ldap_base            : %r" % self._ldap_base)

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -124,6 +124,8 @@ class Auth(auth.BaseAuth):
 
         if self._ldap_ssl_ca_file == "" and self._ldap_ssl_verify_mode != ssl.CERT_NONE and self._ldap_security in ("tls", "starttls"):
             logger.warning("Certificate verification not possible: 'ldap_ssl_ca_file' not set")
+        if self._ldap_ssl_ca_file and self._ldap_security not in ("tls", "starttls"):
+            logger.warning("Config setting 'ldap_ssl_ca_file' useless without encrypted LDAP connection")
 
         logger.info("auth.ldap_uri             : %r" % self._ldap_uri)
         logger.info("auth.ldap_base            : %r" % self._ldap_base)

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -118,6 +118,10 @@ class Auth(auth.BaseAuth):
         elif tmp == "OPTIONAL":
             self._ldap_ssl_verify_mode = ssl.CERT_OPTIONAL
 
+        if self._ldap_uri.lower().startswith("ldaps://") and self._ldap_security not in ("tls", "starttls"):
+            logger.info("Inferring 'ldap_security' = tls from 'ldap_uri' starting with 'ldaps://'")
+            self._ldap_security = "tls"
+
         logger.info("auth.ldap_uri             : %r" % self._ldap_uri)
         logger.info("auth.ldap_base            : %r" % self._ldap_base)
         logger.info("auth.ldap_reader_dn       : %r" % self._ldap_reader_dn)

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -1,6 +1,7 @@
 # This file is part of Radicale - CalDAV and CardDAV server
 # Copyright © 2022-2024 Peter Varkoly
 # Copyright © 2024-2024 Peter Bieringer <pb@bieringer.de>
+# Copyright © 2024-2025 Peter Marschall <peter@adpm.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -122,6 +122,9 @@ class Auth(auth.BaseAuth):
             logger.info("Inferring 'ldap_security' = tls from 'ldap_uri' starting with 'ldaps://'")
             self._ldap_security = "tls"
 
+        if self._ldap_ssl_ca_file == "" and self._ldap_ssl_verify_mode != ssl.CERT_NONE and self._ldap_security in ("tls", "starttls"):
+            logger.warning("Certificate verification not possible: 'ldap_ssl_ca_file' not set")
+
         logger.info("auth.ldap_uri             : %r" % self._ldap_uri)
         logger.info("auth.ldap_base            : %r" % self._ldap_base)
         logger.info("auth.ldap_reader_dn       : %r" % self._ldap_reader_dn)

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -125,50 +125,49 @@ class Auth(auth.BaseAuth):
         if self._ldap_ssl_ca_file and self._ldap_security not in ("tls", "starttls"):
             logger.warning("Config setting 'ldap_ssl_ca_file' useless without encrypted LDAP connection")
 
-        logger.info("auth.ldap_uri             : %r" % self._ldap_uri)
-        logger.info("auth.ldap_base            : %r" % self._ldap_base)
-        logger.info("auth.ldap_reader_dn       : %r" % self._ldap_reader_dn)
-        logger.info("auth.ldap_filter          : %r" % self._ldap_filter)
+        logger.info("auth.ldap_uri               : %r" % self._ldap_uri)
+        logger.info("auth.ldap_base              : %r" % self._ldap_base)
+        logger.info("auth.ldap_reader_dn         : %r" % self._ldap_reader_dn)
+        logger.info("auth.ldap_filter            : %r" % self._ldap_filter)
         if self._ldap_user_attr:
-            logger.info("auth.ldap_user_attribute  : %r" % self._ldap_user_attr)
+            logger.info("auth.ldap_user_attribute    : %r" % self._ldap_user_attr)
         else:
-            logger.info("auth.ldap_user_attribute  : (not provided)")
+            logger.info("auth.ldap_user_attribute    : (not provided)")
         if self._ldap_groups_attr:
-            logger.info("auth.ldap_groups_attribute: %r" % self._ldap_groups_attr)
+            logger.info("auth.ldap_groups_attribute  : %r" % self._ldap_groups_attr)
         else:
-            logger.info("auth.ldap_groups_attribute: (not provided)")
+            logger.info("auth.ldap_groups_attribute  : (not provided)")
         if self._ldap_group_base:
-            logger.info("auth.ldap_group_base     : %r" % self._ldap_group_base)
+            logger.info("auth.ldap_group_base        : %r" % self._ldap_group_base)
         else:
-            logger.info("auth.ldap_group_base     : (not provided, using ldap_base)")
+            logger.info("auth.ldap_group_base        : (not provided, using ldap_base)")
             self._ldap_group_base = self._ldap_base
         if self._ldap_group_filter:
-            logger.info("auth.ldap_group_filter: %r" % self._ldap_group_filter)
+            logger.info("auth.ldap_group_filter      : %r" % self._ldap_group_filter)
         else:
-            logger.info("auth.ldap_group_filter: (not provided)")
+            logger.info("auth.ldap_group_filter      : (not provided)")
         if self._ldap_group_members_attr:
             logger.info("auth.ldap_group_members_attr: %r" % self._ldap_group_members_attr)
         else:
             logger.info("auth.ldap_group_members_attr: (not provided)")
         if ldap_secret_file_path:
-            logger.info("auth.ldap_secret_file_path: %r" % ldap_secret_file_path)
+            logger.info("auth.ldap_secret_file_path  : %r" % ldap_secret_file_path)
             if self._ldap_secret:
-                logger.info("auth.ldap_secret          : (from file)")
+                logger.info("auth.ldap_secret            : (from file)")
         else:
-            logger.info("auth.ldap_secret_file_path: (not provided)")
+            logger.info("auth.ldap_secret_file_path  : (not provided)")
             if self._ldap_secret:
-                logger.info("auth.ldap_secret          : (from config)")
+                logger.info("auth.ldap_secret            : (from config)")
         if self._ldap_reader_dn and not self._ldap_secret:
-            logger.error("auth.ldap_secret         : (not provided)")
+            logger.error("auth.ldap_secret           : (not provided)")
             raise RuntimeError("LDAP authentication requires ldap_secret for ldap_reader_dn")
-        logger.info("auth.ldap_use_ssl         : %s" % ldap_use_ssl)
-        logger.info("auth.ldap_security      : %s" % self._ldap_security)
-        if self._ldap_security in ("tls", "starttls"):
-            logger.info("auth.ldap_ssl_verify_mode : %s" % self._ldap_ssl_verify_mode)
-            if self._ldap_ssl_ca_file:
-                logger.info("auth.ldap_ssl_ca_file     : %r" % self._ldap_ssl_ca_file)
-            else:
-                logger.info("auth.ldap_ssl_ca_file     : (not provided)")
+        logger.info("auth.ldap_use_ssl           : %s" % ldap_use_ssl)
+        logger.info("auth.ldap_security          : %s" % self._ldap_security)
+        logger.info("auth.ldap_ssl_verify_mode   : %s" % self._ldap_ssl_verify_mode)
+        if self._ldap_ssl_ca_file:
+            logger.info("auth.ldap_ssl_ca_file       : %r" % self._ldap_ssl_ca_file)
+        else:
+            logger.info("auth.ldap_ssl_ca_file       : (not provided)")
         if self._ldap_ignore_attribute_create_modify_timestamp:
             logger.info("auth.ldap_ignore_attribute_create_modify_timestamp applied (relevant for ldap3 only)")
         """Extend attributes to to be returned in the user query"""
@@ -176,7 +175,7 @@ class Auth(auth.BaseAuth):
             self._ldap_attributes.append(self._ldap_groups_attr)
         if self._ldap_user_attr:
             self._ldap_attributes.append(self._ldap_user_attr)
-        logger.info("ldap_attributes           : %r" % self._ldap_attributes)
+        logger.info("ldap_attributes             : %r" % self._ldap_attributes)
 
     def _login2(self, login: str, password: str) -> str:
         try:

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -244,34 +244,11 @@ class Auth(auth.BaseAuth):
                     for dn, entry in res:
                         groupDNs.append(dn)
 
-            """Close LDAP connection"""
-            conn.unbind()
         except Exception as e:
             raise RuntimeError(f"Invalid LDAP configuration:{e}")
 
         try:
             """Bind as user to authenticate"""
-            conn = self.ldap.initialize(self._ldap_uri)
-            conn.protocol_version = self.ldap.VERSION3
-            conn.set_option(self.ldap.OPT_REFERRALS, 0)
-
-            if self._ldap_security in ("tls", "starttls"):
-                """certificate validation mode"""
-                if self._ldap_ssl_verify_mode == ssl.CERT_REQUIRED:
-                    conn.set_option(self.ldap.OPT_X_TLS_REQUIRE_CERT, self.ldap.OPT_X_TLS_DEMAND)
-                elif self._ldap_ssl_verify_mode == ssl.CERT_OPTIONAL:
-                    conn.set_option(self.ldap.OPT_X_TLS_REQUIRE_CERT, self.ldap.OPT_X_TLS_ALLOW)
-                else:
-                    conn.set_option(self.ldap.OPT_X_TLS_REQUIRE_CERT, self.ldap.OPT_X_TLS_NONE)
-                """CA file to validate certificate against"""
-                if self._ldap_ssl_ca_file:
-                    conn.set_option(self.ldap.OPT_X_TLS_CACERTFILE, self._ldap_ssl_ca_file)
-                """create TLS context- this must be the last TLS setting"""
-                conn.set_option(self.ldap.OPT_X_TLS_NEWCTX, self.ldap.OPT_ON)
-
-                if self._ldap_security == "starttls":
-                    conn.start_tls_s()
-
             conn.simple_bind_s(user_dn, password)
             if self._ldap_user_attr:
                 if user_entry[1][self._ldap_user_attr]:

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -101,6 +101,8 @@ class Auth(auth.BaseAuth):
             with open(ldap_secret_file_path, 'r') as file:
                 self._ldap_secret = file.read().rstrip('\n')
         self._ldap_security = configuration.get("auth", "ldap_security")
+        if self._ldap_security not in ("none", "tls", "starttls"):
+            raise RuntimeError("Illegal value for config setting ´ldap_security'")
         ldap_use_ssl = configuration.get("auth", "ldap_use_ssl")
         if ldap_use_ssl:
             logger.warning("Configuration uses deprecated 'ldap_use_ssl': use 'ldap_security' ('none', 'tls', 'starttls') instead.")
@@ -115,6 +117,8 @@ class Auth(auth.BaseAuth):
             self._ldap_ssl_verify_mode = ssl.CERT_NONE
         elif tmp == "OPTIONAL":
             self._ldap_ssl_verify_mode = ssl.CERT_OPTIONAL
+        elif tmp != "REQUIRED":
+            raise RuntimeError("Illegal value for config setting ´ldap_ssl_verify_mode'")
 
         if self._ldap_uri.lower().startswith("ldaps://") and self._ldap_security not in ("tls", "starttls"):
             logger.info("Inferring 'ldap_security' = tls from 'ldap_uri' starting with 'ldaps://'")

--- a/radicale/auth/ldap.py
+++ b/radicale/auth/ldap.py
@@ -67,7 +67,6 @@ class Auth(auth.BaseAuth):
     _ldap_group_filter: str
     _ldap_group_members_attr: str
     _ldap_module_version: int = 3
-    _use_encryption: bool = False
     _ldap_security: str = "none"
     _ldap_ssl_verify_mode: int = ssl.CERT_REQUIRED
     _ldap_ssl_ca_file: str = ""
@@ -103,7 +102,6 @@ class Auth(auth.BaseAuth):
                 self._ldap_secret = file.read().rstrip('\n')
         self._ldap_security = configuration.get("auth", "ldap_security")
         ldap_use_ssl = configuration.get("auth", "ldap_use_ssl")
-        self._use_encryption = ldap_use_ssl or self._ldap_security in ("tls", "starttls")
         if ldap_use_ssl:
             logger.warning("Configuration uses deprecated 'ldap_use_ssl': use 'ldap_security' ('none', 'tls', 'starttls') instead.")
             if self._ldap_security == "starttls":
@@ -165,7 +163,7 @@ class Auth(auth.BaseAuth):
             raise RuntimeError("LDAP authentication requires ldap_secret for ldap_reader_dn")
         logger.info("auth.ldap_use_ssl         : %s" % ldap_use_ssl)
         logger.info("auth.ldap_security      : %s" % self._ldap_security)
-        if self._use_encryption:
+        if self._ldap_security in ("tls", "starttls"):
             logger.info("auth.ldap_ssl_verify_mode : %s" % self._ldap_ssl_verify_mode)
             if self._ldap_ssl_ca_file:
                 logger.info("auth.ldap_ssl_ca_file     : %r" % self._ldap_ssl_ca_file)
@@ -272,7 +270,7 @@ class Auth(auth.BaseAuth):
         """Connect the server"""
         try:
             logger.debug(f"_login3 {self._ldap_uri}, {self._ldap_reader_dn}")
-            if self._use_encryption:
+            if self._ldap_security in ("tls", "starttls"):
                 logger.debug("_login3 using encryption (reader)")
                 tls = self.ldap3.Tls(validate=self._ldap_ssl_verify_mode)
                 if self._ldap_ssl_ca_file != "":


### PR DESCRIPTION
Hi Peter,

this PR foremost brings LDAP encryption (tls / starttls) to radicale's `ldap` authentication module when used with Python's `ldap` module.
Until now, any LDAP encryption setting in the config was silently ignored when using the 'ldap' module instead of the 'ldap3' module, which I consider a big secuerity hole.

In addition, it
* prepares for the removal of `ldap_use_ssl`
* gets rid of the helper property `_use_encryption`
* infers `ldap_security=tls` when `ldap_uri` starts with `ldaps://`
* warns on conflicting settings of `ldap_use_ssl` and `ldap_security`
* makes Radicale fail on illegal values for the config settings `ldap_security` and `ldap_ssl_verify_mode`
* lowers `ldap_ssl_verify_mode` to NONE when `ldap_uri` starts with `ldapi://`

Please consider pulling into master.