### PR TITLE
Fix: out-of-range timestamp on 32-bit systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.5.8.dev
 * Extend [auth]: re-factor & overhaul LDPA autrhentication, especially for Python's ldap module
+* Fix: out-of-range timestamp on 32-bit systems
 
 ## 3.5.7
 * Extend: [auth] dovecot: add support for version >= 2.4

--- a/radicale/utils.py
+++ b/radicale/utils.py
@@ -280,10 +280,7 @@ def format_ut(unixtime: int) -> str:
         # TODO check how to support this better
         return str(unixtime)
     if unixtime < DATETIME_MAX_UNIXTIME:
-        if sys.version_info < (3, 11):
-            dt = datetime.datetime.utcfromtimestamp(unixtime)
-        else:
-            dt = datetime.datetime.fromtimestamp(unixtime, datetime.UTC)
+        dt = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc) + datetime.timedelta(seconds=unixtime)
         r = str(unixtime) + "(" + dt.strftime('%Y-%m-%dT%H:%M:%SZ') + ")"
     else:
         r = str(unixtime) + "(>MAX:" + str(DATETIME_MAX_UNIXTIME) + ")"


### PR DESCRIPTION
as suggested by https://github.com/dateutil/dateutil/issues/1436

Fixing https://github.com/Kozea/Radicale/issues/1851 and https://github.com/Kozea/Radicale/issues/1888