### PR TITLE
fix typo in changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.5.8.dev
-* Extend [auth]: re-factor & overhaul LDPA autrhentication, especially for Python's ldap module
+* Extend [auth]: re-factor & overhaul LDAP authentication, especially for Python's ldap module
 * Fix: out-of-range timestamp on 32-bit systems
 
 ## 3.5.7


### PR DESCRIPTION
Hi Peter,

In commit 8ae5831e9c7aafbbf719949a05ef7ae3425a5576, I updated CHANGELOG.md a bit to hastily, and overlooked (embarrassing) 2 typos.

Please consider pulling into master.