### PR TITLE
Docker publish workflow: Add stable, major, and minor tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,8 +37,11 @@ jobs:
           flavor: latest=true
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
             type=schedule,prefix=nightly-,pattern={{date 'YYYYMMDD'}}
             type=raw,enable=${{ github.event_name == 'workflow_dispatch' }},value=workflow_dispatch-{{branch}}-{{sha}}
+            type=raw,enable=${{ github.event_name == 'release' }},value=stable
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
For every release, add the following tags:

1. "stable" - The latest stable release can be obtained using this tag
2. major and minor

The "latest" tag remains as-is. It will always point to the latest image (stable or otherwise)



This is as per request in https://github.com/Kozea/Radicale/discussions/1745#discussioncomment-15244341

> Thanks a lot for your efforts to provide an official container image.
> 
> What prevents me from using it is the lack of a "stable" tag name that refers to the latest stable version. It would be great if you could add the major and minor versions as tags to the images. For example, the tags `3` and `3.5` should refer to the latest version of the major branch `3` and the minor branch `3.5`, respectively.
> 
> (snip)


Regarding major and minor tags, this strategy is used in popular projects. For example, here is a screenshot for docker tags of [alpine](https://hub.docker.com/_/alpine/tags):

<img width="642" height="879" alt="Screenshot from 2025-12-21 21-43-17" src="https://github.com/user-attachments/assets/9f8363b6-b556-4c30-83dd-9039a65fcc4a" />

Note that for tags [3.23.2](https://hub.docker.com/layers/library/alpine/3.23.2/images/sha256-16ff8a639f58b38d94b054e94c106dbbd8a60d45f8b1989f98516a3e8e0792ad), [3.23](https://hub.docker.com/layers/library/alpine/3.23/images/sha256-16ff8a639f58b38d94b054e94c106dbbd8a60d45f8b1989f98516a3e8e0792ad) and [3](https://hub.docker.com/layers/library/alpine/3/images/sha256-16ff8a639f58b38d94b054e94c106dbbd8a60d45f8b1989f98516a3e8e0792ad),  the values in the "Digest" column are the same, indicating that this is the same image having multiple tags.

This is useful because users can specify "major" or "major.minor" tags in the docker compose file and get the latest compatible releases without changing the compose file.