### PR TITLE
fix misindented early return

### DIFF
--- a/radicale/hook/email/__init__.py
+++ b/radicale/hook/email/__init__.py
@@ -988,7 +988,7 @@ class Hook(BaseHook):
                 if event_end < (now - timedelta(minutes=1)):
                     logger.warning("Event end time is in the past, skipping notification for event: %s",
                                    email_event_event.uid)
-                return
+                    return
 
             if not previous_item_str:
                 # Dealing with a completely new event, no previous content to compare against.


### PR DESCRIPTION
The wrong indentation could cause the mail hook to bail early without any logging when the end time of the event being added/modified happened later than the current boundary being checked (1 full minute before the current time).

For example, this caused emails not to be sent in the following setup: Etar + DAVx⁵ on Android.

Fixes #1917