### PR TITLE
Docker compose file - change tag to "stable"

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 name: Radicale
 services:
     radicale:
-        image: ghcr.io/kozea/radicale:3.5.10
+        image: ghcr.io/kozea/radicale:stable
         ports:
         - 5232:5232
         volumes:


### PR DESCRIPTION
In https://github.com/Kozea/Radicale/pull/1950

> **Please note**:
> For now, the latest release (`3.5.10`) is hardcoded in the compose file. After next release, I will create another PR to change it to `stable`. This tag will always point to the latest stable docker image version.

This PR makes the above change