### PR TITLE
Add `git` to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 RUN addgroup -g 1000 radicale \
     && adduser radicale --home /var/lib/radicale --system --uid 1000 --disabled-password -G radicale \
-    && apk add --no-cache ca-certificates openssl curl
+    && apk add --no-cache ca-certificates openssl curl git
 
 COPY --chown=radicale:radicale --from=builder /app/venv /app
 


### PR DESCRIPTION
This is required to version collections with git as described in the tutorial at https://radicale.org/v3.html#versioning-collections-with-git .