### PR TITLE
Incorrect comma deleted and indentation corrected in predefined_colle…

### DIFF
--- a/config
+++ b/config
@@ -291,8 +291,8 @@
 #       "C:supported-calendar-component-set": "VEVENT",
 #       "D:displayname": "Work Calendar",
 #       "tag": "VCALENDAR"
-#    },
-# }
+#    }
+#  }
 #predefined_collections =
 
 


### PR DESCRIPTION
I made a small mistake during the initial setup. Therefore, here's the correction. Otherwise, if the user uses it as a template, the container won't start.