### PR TITLE
Ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage.xml
 Gemfile.lock
 
 pytestdebug.log
+uv.lock


### PR DESCRIPTION
This allows development using the uv tool without showing the commit as dirty