### PR TITLE
Improve performance of `path_to_filesystem()`

### DIFF
--- a/radicale/pathutils.py
+++ b/radicale/pathutils.py
@@ -285,9 +285,8 @@ def path_to_filesystem(root: str, sane_path: str) -> str:
         safe_path = os.path.join(safe_path, part)
         # Check for conflicting files (e.g. case-insensitive file systems
         # or short names on Windows file systems)
-        if (os.path.lexists(safe_path) and
-            not os.path.realpath(safe_path).endswith(part)):
-                raise CollidingPathError(part)
+        if (os.path.lexists(safe_path) and not os.path.realpath(safe_path).endswith(part)):
+            raise CollidingPathError(part)
     return safe_path
 
 


### PR DESCRIPTION
When using radicale with a large set of accounts, the `PROPFIND` request at `/`, even with simple `owners_only` access rights, is very long (more than 100 seconds with 100% CPU on my test).

The bottleneck seems to be in the function `path_to_filesystem()` which is called for every folder (so for every account, when listing `/`), more precisely in the part in which it lists again this large folder.

This patch aims to check the same cases (short names on windows and case-insensitivity) with a different approach. In my test, the `PROPFIND` at `/` goes from 120 seconds to 3 seconds.