### PR TITLE
Bugfix: Set folder_db for csv database

### DIFF
--- a/radicale/sharing/csv.py
+++ b/radicale/sharing/csv.py
@@ -40,6 +40,8 @@ class Sharing(sharing.BaseSharing):
             sharing_db_file = os.path.join(folder_db, "sharing.csv")
             logger.info("sharing database filename not provided, use default: %r", sharing_db_file)
         else:
+            sharing_db_file = os.path.abspath(sharing_db_file)
+            folder_db = os.path.dirname(sharing_db_file)
             logger.info("sharing database filename: %r", sharing_db_file)
 
         if not os.path.exists(folder_db):


### PR DESCRIPTION
This fixes the error message:
[ERROR] sharing database cannot be initialized: UnboundLocalError("cannot access local variable 'folder_db' where it is not associated with a value")