### PR TITLE
Preload access rights from file

### DIFF
--- a/radicale/rights/from_file.py
+++ b/radicale/rights/from_file.py
@@ -45,6 +45,7 @@ from radicale.log import logger
 class Rights(rights.BaseRights):
 
     _filename: str
+    _rights_config: dict
 
     def __init__(self, configuration: config.Configuration) -> None:
         super().__init__(configuration)


### PR DESCRIPTION
configparser is quite slow and can slow down `from_file` access rights on large collections.

For instance on my lab with 100,000 accounts, a `PROPFIND` on `/` lasts (with #2002 already integrated):
* 22 seconds with `from_files`
* 13 seconds with `owner_only`

The proposed patch extracts configparser settings during `__init__()` and stores them in a dict. In the same lab, the `PROPFIND` requests last 15 seconds, which is nearly as good as `owner_only`.

Note : I also tried to pre-compile regexps but this did not yield a visible performance improvement, configparser really seems to be the bottleneck here.