### PR TITLE
sharing info hook extension related to properties overlay

### DIFF
--- a/SHARING.md
+++ b/SHARING.md
@@ -253,7 +253,7 @@ Can be selected by `HTTP_ACCEPT` - default is equal to provided `CONTENT_TYPE`
 
 ##### API Hook "info"
 
-Shows what kind of ShareTypes are supported
+Shows what is active/supported like ShareTypes(Feature), Conversions or permission to create or use properties overlay (depending on config options)
 
  * Output: text/plain|application/json
 
@@ -270,6 +270,8 @@ PermittedCreateCollectionByMap=True
 FeatureEnabledCollectionByToken=True
 PermittedCreateCollectionByToken=True
 SupportedConversions=(bday none)
+PermittedPropertiesOverlay=True
+SupportedPropertiesOverlay=(C:calendar-description ICAL:calendar-color CR:addressbook-description INF:addressbook-color D:displayname)
 ```
 
   * json->json, parsed with `jq`
@@ -284,7 +286,9 @@ curl -u user:$userpw --silent -H "accept: application/json" -d "" http://localho
   "PermittedCreateCollectionByMap": true,
   "FeatureEnabledCollectionByToken": true,
   "PermittedCreateCollectionByToken": true,
-  "SupportedConversions": ["bday", "none"]
+  "SupportedConversions": ["bday", "none"],
+  "PermittedPropertiesOverlay": true,
+  "SupportedPropertiesOverlay": ["C:calendar-description", "ICAL:calendar-color", "CR:addressbook-description", "INF:addressbook-color", "D:displayname"]
 }
 ```
 

--- a/radicale/sharing/__init__.py
+++ b/radicale/sharing/__init__.py
@@ -117,6 +117,8 @@ API_TYPES_V1: dict[str, type] = {
         "Conversion": str,
         "Actions": dict,
         "SupportedConversions": list,
+        "PermittedPropertiesOverlay": bool,
+        "SupportedPropertiesOverlay": list,
 }
 
 
@@ -1261,8 +1263,10 @@ class BaseSharing:
             if ShareType in ["all", "token"]:
                 answer['FeatureEnabledCollectionByToken'] = self.sharing_collection_by_token
                 answer['PermittedCreateCollectionByToken'] = self.permit_create_token
-            if ShareType in ["all", "map", "token"]:
+            if ShareType in SHARE_TYPES:
                 answer['SupportedConversions'] = CONVERSIONS_WHITELIST
+                answer['PermittedPropertiesOverlay'] = self.permit_properties_overlay
+                answer['SupportedPropertiesOverlay'] = OVERLAY_PROPERTIES_WHITELIST
 
         # action: TOGGLE
         elif action in API_SHARE_TOGGLES_V1:

--- a/radicale/tests/test_sharing.py
+++ b/radicale/tests/test_sharing.py
@@ -366,6 +366,7 @@ class TestSharingApiSanity(BaseTest):
                                         "collection_by_map": "True",
                                         "collection_by_token": "True",
                                         "permit_create_map": "True",
+                                        "permit_properties_overlay": "True",
                                         "permit_create_token": "True"}
                             })
             logging.info("\n*** check API hook: info/all")
@@ -376,7 +377,16 @@ class TestSharingApiSanity(BaseTest):
             assert answer_dict['FeatureEnabledCollectionByToken'] is True, f'FeatureEnabledCollectionByToken {db_type}'
             assert answer_dict['PermittedCreateCollectionByMap'] is True, f'PermittedCreateCollectionByMap {db_type}'
             assert answer_dict['PermittedCreateCollectionByToken'] is True, f'PermittedCreateCollectionByToken {db_type}'
-            assert answer_dict['SupportedConversions'] == ["bday", "none"]
+            assert answer_dict['SupportedConversions'] == list(sharing.CONVERSIONS_WHITELIST)
+            assert answer_dict['PermittedPropertiesOverlay'] is True
+            assert answer_dict['SupportedPropertiesOverlay'] == list(sharing.OVERLAY_PROPERTIES_WHITELIST)
+
+            logging.info("\n*** check API hook: info/all (2)")
+            self.configure({"sharing": {"permit_properties_overlay": "False"}})
+            json_dict = {}
+            _, headers, answer = self._sharing_api_json("all", "info", check=200, login="owner:ownerpw", json_dict=json_dict)
+            answer_dict = json.loads(answer)
+            assert answer_dict['PermittedPropertiesOverlay'] is False
 
     def test_sharing_api_list_with_auth(self) -> None:
         """POST/list with authentication."""


### PR DESCRIPTION
@maxberger - potentially useful for `radicale/web/internal_data/js/api/sharing.js` to toggle whether COLOR or DESCRIPTION are changeable at all (before triggering PROPPATCH, which would be then not successful)

properties overwrite cases are
- "w" not in permissions && PermittedPropertiesOverlay == true && "p" not in permissions
- "w" not in permissions && PermittedPropertiesOverlay == false && "P" in permissions