### PR TITLE
fix(auth): prevent login variable overwrite during failed cache cleanup

### DIFF
--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -275,8 +275,8 @@ class BaseAuth:
                 logger.debug("Login failed cache cleanup start (entries: %d)", cache_failed_cleanup_entries)
                 if cache_failed_cleanup_entries > 0:
                     for digest in cache_failed_cleanup:
-                        (login, age_failed) = cache_failed_cleanup[digest]
-                        logger.debug("Login failed cache entry for user+password expired: '%s' (age: %d > %d sec)", login_cache, age_failed, self._cache_failed_logins_expiry)
+                        (login_expired, age_failed) = cache_failed_cleanup[digest]
+                        logger.debug("Login failed cache entry for user+password expired: '%s' (age: %d > %d sec)", login_expired, age_failed, self._cache_failed_logins_expiry)
                         del self._cache_failed[digest]
                 self._lock.release()
                 logger.debug("Login failed cache investigation finished")


### PR DESCRIPTION
In the failed login cache cleanup loop, the tuple unpacking was using `login` as the local variable name, silently overwriting the current user's login with the one retrieved from the expired cache entry.

This caused subsequent backend authentication (e.g. IMAP) to be attempted with the wrong username, resulting in spurious auth failures for legitimate users whenever an expired failed-cache entry happened to be present at the same time.

Rename the loop variable to `login_expired` to avoid shadowing the outer `login` variable, and fix the associated debug log to reference `login_expired` instead of the previously incorrect `login_cache`.

Fixes: intermittent authentication failures when _cache_failed contains expired entries from previous failed login attempts by other users.