### PR TITLE
setup: drop leftover dependency "packaging"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Fix: broken storage/mtime granularity detection on vfat
 * Improve: `path_to_filesystem()` by pre-detection of collision-free file system
 * Adjustment: MKCOL/MKCALENDAR return now CONFLICT instead of BADREQUEST of file name collision
-* Improve: [auth] catch bcrypt>=5.0.0 enforced max password length early and support legacy "passlib" as well as "libpass" (rework 3.6.0)
+* Improve: [auth] catch bcrypt>=5.0.0 enforced max password length early and support legacy "passlib" as well as "libpass" (rework 3.6.0, "packaging" not needed anymore)
 
 ## 3.7.1
 * Fix: share address book collection as birthday calendar not working on non-DEBUG level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "vobject>=0.9.6",
     "pika>=1.1.0",
     "requests",
-    "packaging",
 ]
 
 

--- a/setup.py.legacy
+++ b/setup.py.legacy
@@ -41,7 +41,6 @@ web_files = ["web/internal_data/css/icon.png",
 install_requires = ["defusedxml", "libpass>=1.9.3", "vobject>=0.9.6",
                     "pika>=1.1.0",
                     "requests",
-                    "packaging",
                     ]
 bcrypt_requires = ["bcrypt"]
 argon2_requires = ["argon2-cffi"]


### PR DESCRIPTION
Fixes: 6690e9e3ca80 ("radicale/utils: drop bcrypt compat check")