### PR TITLE
UI: Only clear errors on successful login

### DIFF
--- a/integ_tests/test_scenes_login.py
+++ b/integ_tests/test_scenes_login.py
@@ -53,3 +53,32 @@ def test_login_logout_login(page: Page, radicale_server: str, config: Config) ->
     # 3. Second login
     login(page, radicale_server, config)
     expect(page.locator("#collectionsscene")).to_be_visible()
+
+
+def test_login_wrong_password_shows_error(
+    page: Page, radicale_server: str, config: Config
+) -> None:
+    page.goto(radicale_server)
+
+    # 1. Login with wrong password
+    page.fill('#loginscene input[data-name="user"]', "admin")
+    page.fill('#loginscene input[data-name="password"]', "wrongpassword")
+    page.click('button:has-text("Next")')
+
+    # Expect error message to be shown
+    expect(page.locator('#loginscene [data-name="error"]')).to_be_visible()
+
+    # 2. Login with right password
+    page.fill('#loginscene input[data-name="password"]', "admi$pass#word")
+    page.click('button:has-text("Next")')
+
+    # Expect successful login
+    expect(page.locator("#collectionsscene")).to_be_visible()
+
+    # 3. Logout
+    page.click('#logoutview a[data-name="logout"]')
+    expect(page.locator("#loginscene")).to_be_visible()
+    expect(page.locator("#collectionsscene")).to_be_hidden()
+
+    # Expect error message is NOT shown
+    expect(page.locator('#loginscene [data-name="error"]')).not_to_be_visible()

--- a/radicale/web/internal_data/js/scenes/LoginScene.js
+++ b/radicale/web/internal_data/js/scenes/LoginScene.js
@@ -90,6 +90,8 @@ export class LoginScene {
                 this._errorHandler.setError(error1);
                 pop_scene();
             } else if (principal_collection) {
+                // clear error on successful login
+                this._errorHandler.clearError();
                 // show collections
                 let saved_user = this._user;
                 this._user = "";
@@ -145,7 +147,6 @@ export class LoginScene {
     }
 
     show() {
-        this._errorHandler.clearError();
         this._remove_logout();
         this._fill_form();
         this._form.onsubmit = () => this._onlogin();


### PR DESCRIPTION
The last patch was overly eager to clear errors, we should only clear them on successful login. Added an integ test to make sure this does the right thing.