### PR TITLE
Authentication cache breaks when password changes

### DIFF
--- a/radicale/auth/__init__.py
+++ b/radicale/auth/__init__.py
@@ -306,6 +306,7 @@ class BaseAuth:
                         result_from_cache = True
                 else:
                     logger.debug("Login successful cache entry for user+password not matching: '%s'", login)
+                    digest = ""
             else:
                 # login not found in cache, caculate always to avoid timing attacks
                 digest = self._cache_digest(login, password, str(time_ns))


### PR DESCRIPTION
When a user changes his password, authentication cache for this user will never work again (until restart).

Here's how to reproduce : 
* Authenticate `user1`. This populates the cache
* Authenticate `user1` and check that authentication cache is used
* Change user1's password
* Authenticate `user1` with the new password, authentication cache is not used but it works
* Authenticate `user1` again, even after cache expiry time, authentication cache is not used but it works

In fact, in `auth/__init__.py::login()`, after the password change (line numbers in the upstream code) : 
* We enter the condition in L292
* We execute L295 `digest = self._cache_digest(login, password, str(time_ns_cache))` with `time_ns_cache` coming from `self._cache_successful`
* We don't enter L296 since we give the new password
* We enter L312 (auth successful from the backend)
* We execute L323 `self._cache_successful[login] = (digest, time_ns)`, but `digest` was calculated with `time_ns_cache` on L295 and so does not match the "future one" (at next auth) which will be calculated with `time_ns`
* At this point, the cache is thus "refreshed" but with an inconsistent entry

The PR proposes to empty `digest` when cache fails to authenticate to recalculate `digest` on L320. I don't think it can introduce a timing attack but, well, this part is quite critical...