### PR TITLE
UI: Trim owner length for incoming shares

### DIFF
--- a/radicale/web/internal_data/js/scenes/IncomingSharingScene.js
+++ b/radicale/web/internal_data/js/scenes/IncomingSharingScene.js
@@ -22,7 +22,7 @@
 import { update_incoming_share } from "../api/sharing.js";
 import { collectionsCache } from "../utils/collections_cache.js";
 import { ErrorHandler } from "../utils/error.js";
-import { get_element, get_element_by_id } from "../utils/misc.js";
+import { get_element, get_element_by_id, trim_to_max } from "../utils/misc.js";
 import { displayPermissionsOrConversion } from "../utils/permissions.js";
 import { UrlTextHandler } from "../utils/url_text.js";
 import { Scene, pop_scene } from "./scene_manager.js";
@@ -122,7 +122,7 @@ export class IncomingSharingScene {
             let copy_btn = /** @type {HTMLButtonElement} */ (get_element(node, "[data-name=copy-url]"));
 
             new UrlTextHandler(pathortoken, copy_btn).setHref(share.PathOrToken);
-            owner_td.textContent = share.Owner;
+            owner_td.textContent = trim_to_max(share.Owner, 12);
             displayPermissionsOrConversion(share.Conversion, share.Permissions, permissions_td);
 
             let enabled = share.EnabledByUser !== null ? share.EnabledByUser : true;

--- a/radicale/web/internal_data/js/utils/misc.js
+++ b/radicale/web/internal_data/js/utils/misc.js
@@ -132,3 +132,17 @@ export function get_element(node, selector) {
     }
     return /** @type {HTMLElement} */ (element);
 }
+
+/**
+ * Trim a string to the given maximum number of characters
+ *
+ * @param {string} str
+ * @param {number} max
+ * @returns {str}
+ */
+export function trim_to_max(str, max) {
+    if (str.length > max - 2) {
+        return str.substring(0, max) + "...";
+    }
+    return str;
+}


### PR DESCRIPTION
This should ensure icons are visible in cases with overly long owner names such as in [#2097](https://github.com/Kozea/Radicale/issues/2097)