### PR TITLE
tiny documentation correction

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1630,7 +1630,7 @@ Available types are:
 * `no-unicode` (no unicode)
 * `strict` (reduced ASCII set)
 
-Default: `minimum`
+Default: `minimal`
 
 ##### validate_path_type
 
@@ -1644,7 +1644,7 @@ Validate path value content
 * `no-unicode` (no unicode)
 * `strict` (reduced ASCII set)
 
-Default: `minimum`
+Default: `minimal`
 
 ##### hook
 


### PR DESCRIPTION
When checking out the documentation for the new features I saw that the default value does not exist for `validate_user_value`:
https://radicale.org/master.html#validate_user_value
same with `validate_path_type`.

This fixes the docs, thanks for Radicale and have a great day!