### PR TITLE
Sharing fix propfind owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.7.4.dev
+* Fix: sharing: PROPFIND returns now empty owner element in case of a mapped share as clients try PROPFIND on this not accessable href
 
 ## 3.7.3
 * Extension: expose RADICALE:version for authenticated users via PROPFIND

--- a/radicale/app/propfind.py
+++ b/radicale/app/propfind.py
@@ -395,7 +395,8 @@ def xml_propfind_response(
                 is404 = True
         elif tag == xmlutils.make_clark("D:owner"):
             # return empty elment, if no owner available (rfc3744-5.1)
-            if collection.owner:
+            # return empty element in case of a mapped share / clients try PROPFIND on this not accessable href
+            if collection.owner and not share:
                 child_element = ET.Element(xmlutils.make_clark("D:href"))
                 child_element.text = xmlutils.make_href(
                     base_prefix, "/%s/" % collection.owner)

--- a/radicale/tests/test_sharing.py
+++ b/radicale/tests/test_sharing.py
@@ -2236,15 +2236,18 @@ class TestSharingApiSanity(BaseTest):
 <propfind xmlns="DAV:">
     <prop>
         <current-user-principal />
+        <owner />
     </prop>
 </propfind>""", login="user:userpw", check=207)
             logging.info("response: %r", responses)
             response = responses[path_shared]
-            assert not isinstance(response, int) and len(response) == 1
+            assert not isinstance(response, int) and len(response) == 2
             status, prop = response["D:current-user-principal"]
             assert status == 200 and len(prop) == 1
             element = prop.find(xmlutils.make_clark("D:href"))
             assert element is not None and element.text == "/user/"
+            status, prop = response["D:owner"]
+            assert status == 200 and len(prop) == 0
 
     def test_sharing_api_map_proppatch_acl(self) -> None:
         """share-by-map API usage tests related to report."""


### PR DESCRIPTION
found during log analysis and regression that exposed owner href will be tried to access by clients (here at least DAVx5).