### PR TITLE
Sharing propfind privilege write exposure improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.7.4.dev
 * Fix: sharing: PROPFIND returns now empty owner element in case of a mapped share as clients try PROPFIND on this not accessable href
+* Improve: sharing: PROPFIND returns also privilege "write" in case "write-content" and "write-properties" is permitted
 
 ## 3.7.3
 * Extension: expose RADICALE:version for authenticated users via PROPFIND

--- a/radicale/app/propfind.py
+++ b/radicale/app/propfind.py
@@ -316,10 +316,12 @@ def xml_propfind_response(
             privileges = ["D:read"]
             if share:
                 logger.trace("PROPFIND/xml_propfind_response/current-user-privilege-set: raw_permissions=%r share[Permissions]=%r permit_properties_overlay=%s", raw_permissions, share['Permissions'], self._sharing.permit_properties_overlay)
+                permit_write_content = False
                 if write:
                     if "w" in share['Permissions']:
                         if not share_bday_automap:
                             privileges.append("D:write-content")
+                            permit_write_content = True
                 # priority share->rights->global
                 if ("P" in share['Permissions'] or
                     ("P" in raw_permissions and "p" not in share['Permissions']) or
@@ -330,6 +332,9 @@ def xml_propfind_response(
                             (not self._sharing.permit_properties_overlay and "P" not in raw_permissions and "P" not in share['Permissions'])):
                     logger.trace("PROPFIND/xml_propfind_response/current-user-privilege-set: add D:write-properties")
                     privileges.append("D:write-properties")
+                    # "write-content" + "write-properties" = "write" (rfc3744-3.2)
+                    if permit_write_content:
+                        privileges.append("D:write")
             elif write:
                 privileges.append("D:all")
                 privileges.append("D:write")

--- a/radicale/tests/test_sharing.py
+++ b/radicale/tests/test_sharing.py
@@ -3475,12 +3475,27 @@ permissions: RrWw""")
             _, headers, answer = self._sharing_api_json("map", "enable", check=200, login="user1:user1pw", json_dict=json_dict)
 
             # check PROPFIND/privileges item as user
-            logging.info("\n*** PROPFIND/privileges item as user")
+            logging.info("\n*** PROPFIND/privileges item as user (rw, no P)")
             privileges_list = self._propfind_privileges(path_user1_rw, login="user1:user1pw")
             assert "D:read" in privileges_list
             assert "D:write-content" in privileges_list
             assert "D:write-properties" not in privileges_list
             assert "D:write" not in privileges_list
+            assert "D:all" not in privileges_list
+
+            logging.info("\n*** create map user1/owner1 rwP-> 200")
+            json_dict = {}
+            json_dict['PathMapped'] = path_owner1_rw
+            json_dict['PathOrToken'] = path_user1_rw
+            json_dict['Permissions'] = "rwP"
+            _, headers, answer = self._sharing_api_json("map", "update", check=200, login="owner1:owner1pw", json_dict=json_dict)
+
+            logging.info("\n*** PROPFIND/privileges item as user (rwP)")
+            privileges_list = self._propfind_privileges(path_user1_rw, login="user1:user1pw")
+            assert "D:read" in privileges_list
+            assert "D:write-content" in privileges_list
+            assert "D:write-properties" in privileges_list
+            assert "D:write" in privileges_list
             assert "D:all" not in privileges_list
 
             logging.info("\n*** create map user1/owner1 with adjusted default permissions -> 200")


### PR DESCRIPTION
In case `write-content` + `write-properties` is permitted, also expose `write` in PROPFIND request related to privileges.

Found in real-life that caldavsynchronizer is not proper honoring `write-content` privilege, see also

https://sourceforge.net/p/outlookcaldavsynchronizer/tickets/2161/

Note, in case of `write-properties` is not permitted for a share, the warnings can be ignored until client is fixed.