### PR TITLE
Fix bday conversion hrefs for vCard filenames ending in v/c/f

### DIFF
--- a/radicale/app/propfind.py
+++ b/radicale/app/propfind.py
@@ -159,7 +159,7 @@ def xml_propfind_response(
         if uri.startswith(share['PathMapped']):
             uri = str(share['PathOrToken']) + uri.removeprefix(share['PathMapped'])
         if share_bday_automap and uri.endswith(".vcf"):
-            uri = uri.rstrip(".vcf") + ".ics"
+            uri = uri.removesuffix(".vcf") + ".ics"
 
     href.text = xmlutils.make_href(base_prefix, uri)
     response.append(href)

--- a/radicale/item/__init__.py
+++ b/radicale/item/__init__.py
@@ -592,7 +592,7 @@ class Item:
 
         href = self.href
         if href is not None:
-            href = href.rstrip(".vcf") + ".ics"
+            href = href.removesuffix(".vcf") + ".ics"
 
         etag = self.etag
         # replace 14 leading chars of etag "<hexdigits>" by special format bda0YYYYMMDD00


### PR DESCRIPTION
The bday conversion maps .vcf hrefs to .ics hrefs using `rstrip(".vcf")`.

In Python, `rstrip(".vcf")` removes any trailing characters from the set `., v, c, f` instead of just removing the literal `.vcf` suffix.

For example:
```
"21757fa1-03d6-4cd6-a20a-7b581c7ad9cc.vcf".rstrip(".vcf") + ".ics"
```
produces:

```
21757fa1-03d6-4cd6-a20a-7b581c7ad9.ics
```

instead of:
```
21757fa1-03d6-4cd6-a20a-7b581c7ad9cc.ics
```

This breaks generated birthday calendar items when the source vCard basename ends in `v`, `c`, `f`, or `.`.

The fix is to use `removesuffix()` instead.