### PR TITLE
UI: Avoid redundant URL completion in CollectionsScene

### DIFF
--- a/radicale/web/internal_data/js/scenes/CollectionsScene.js
+++ b/radicale/web/internal_data/js/scenes/CollectionsScene.js
@@ -25,7 +25,7 @@ import { Collection, CollectionType, Permission } from "../models/collection.js"
 import { extract_title } from "../utils/collection_utils.js";
 import { collectionsCache } from "../utils/collections_cache.js";
 import { ErrorHandler } from "../utils/error.js";
-import { bytesToHumanReadable, completeHref, get_element, get_element_by_id } from "../utils/misc.js";
+import { bytesToHumanReadable, get_element, get_element_by_id } from "../utils/misc.js";
 import { UrlTextHandler } from "../utils/url_text.js";
 import { CreateEditCollectionScene } from "./CreateEditCollectionScene.js";
 import { DeleteConfirmationScene } from "./DeleteConfirmationScene.js";

--- a/radicale/web/internal_data/js/scenes/CollectionsScene.js
+++ b/radicale/web/internal_data/js/scenes/CollectionsScene.js
@@ -268,7 +268,7 @@ export class CollectionsScene {
             }
             contentcount_form.textContent = contentcount_form_txt;
         }
-        let href = completeHref(collection.href);
+        let href = window.location.origin + collection.href;
         new UrlTextHandler(url_form, copy_btn).setHref(href);
         download_btn.href = href;
         download_btn.onclick = (event) => {


### PR DESCRIPTION
**Problem Description:**
Redundant URL completion in `CollectionsScene.js`. The file passes a `collection.href` that already contains the full path prefix to `UrlTextHandler.setHref`. Because `setHref` internally calls `completeHref` again, the path is double-completed (over-completed), resulting in a malformed URL.

**Solution:**
Instead of using `completeHref(collection.href)`, use `window.location.origin + collection.href` to manually construct the full URL, preventing the secondary completion bug.