### PR TITLE
UI: Decode URL in text field for better readability

### DIFF
--- a/radicale/web/internal_data/js/scenes/CollectionsScene.js
+++ b/radicale/web/internal_data/js/scenes/CollectionsScene.js
@@ -124,7 +124,7 @@ export class CollectionsScene {
     _ondelete(collection) {
         try {
             let delete_collection_scene = new DeleteConfirmationScene(
-                this._user, this._password, "Delete Collection", collection, collection.displayname || collection.href,
+                this._user, this._password, "Delete Collection", collection, collection.displayname || decodeURIComponent(collection.href),
                 delete_collection, true
             );
             push_scene(delete_collection_scene);
@@ -253,7 +253,7 @@ export class CollectionsScene {
                 edit_btn.classList.add("hidden");
             }
         }
-        title_form.textContent = collection.displayname || collection.href;
+        title_form.textContent = collection.displayname || decodeURIComponent(collection.href);
         if (title_form.textContent.length > 30) {
             title_form.classList.add("smalltext");
         }

--- a/radicale/web/internal_data/js/scenes/CreateEditCollectionScene.js
+++ b/radicale/web/internal_data/js/scenes/CreateEditCollectionScene.js
@@ -196,7 +196,7 @@ export class CreateEditCollectionScene {
         this._remove_invalid_types();
         this._html_scene.classList.remove("hidden");
         if (this._edit && this._title_form) {
-            this._title_form.textContent = this._collection.displayname || this._collection.href;
+            this._title_form.textContent = this._collection.displayname || decodeURIComponent(this._collection.href);
         }
         this._fill_form();
         this._submit_btn.onclick = () => this._onsubmit();


### PR DESCRIPTION
This PR is a follow-up to #2138. It extends the URL decoding logic to include the delete and edit collection dialogs, as well as homepage collection titles, ensuring a consistent user experience.