### PR TITLE
Hide copy button in insecure environments

### DIFF
--- a/radicale/web/internal_data/js/utils/url_text.js
+++ b/radicale/web/internal_data/js/utils/url_text.js
@@ -63,7 +63,11 @@ export class UrlTextHandler {
         });
 
         if (this._copyButton) {
-            this._copyButton.onclick = () => this._oncopy();
+            if (typeof window !== "undefined" && !window.isSecureContext) {
+                this._copyButton.classList.add("hidden");
+            } else {
+                this._copyButton.onclick = () => this._oncopy();
+            }
         }
     }
 


### PR DESCRIPTION
writing to clipboard via javascript only works in secure environments. Likely cause for Issue #2137