### PR TITLE
Docker nightly build - Do not run if cannot log in to dockerhub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,12 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+
+    # Avoid running nightly build if dockerhub credentials are absent
+    # This should prevent triggering nightly builds on forks
+    if: |
+      github.event_name != 'schedule' ||
+      vars.DOCKERHUB_ORGNAME != ''
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
* This is detected by presence of `vars.DOCKERHUB_ORGNAME`
* `secrets/DOCKERHUB_TOKEN` could not be used
* Other builds are unaffected