### PR TITLE
Upgrade to html5validator-2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ commands_pre = [["playwright", "install", "chromium"]]
 commands = [["pytest", "integ_tests"]]
 
 [tool.tox.env.html5validator]
-deps = ["html5validator"]
+deps = ["html5validator-2"]
 commands = [["html5validator", "--root", "radicale/web/internal_data/", "--also-check-css"]]
 
 


### PR DESCRIPTION
See https://pypi.org/project/html5validator-2/ vs
https://pypi.org/project/html5validator/

This is by the same maintainer as the github action used in the workflow.

It also supports css color-scheme, which has recently been added to support dark mode.