### PR TITLE
contrib/ferron: add Ferron example configuration

### DIFF
--- a/contrib/ferron/radicale.kdl
+++ b/contrib/ferron/radicale.kdl
@@ -1,0 +1,8 @@
+// Minimal configuration for Ferron web server v2
+
+example.com {
+	location "/radicale" remove_base=#true {
+		proxy "http://localhost:5232"
+		proxy_request_header "X-Script-Name" "/radicale"
+	}
+}


### PR DESCRIPTION
Add a minimal configuration for making Radicale work with [Ferron](https://ferron.sh/) web server.

The version of Ferron is 2. Other versions use different file formats, but with version 1.x I was not able to make Radicale work, while version 3 is still in beta.