### PR TITLE
UI: disable conversion mode buttons on edit

### DIFF
--- a/integ_tests/test_sharing.py
+++ b/integ_tests/test_sharing.py
@@ -423,6 +423,16 @@ def test_create_and_delete_share_by_bday(
         )
     ).to_have_count(1)
 
+    # Edit the bday share to verify that the conversion selection is disabled in the loaded state
+    page.click(
+        "tr[data-name='sharemaprowtemplate']:not(.hidden) button[data-name='edit']",
+        strict=True,
+    )
+    expect(page.locator("#createeditsharescene h1")).to_have_text("Edit Share")
+    expect(page.locator("input#newshare_conv_none")).to_be_disabled()
+    expect(page.locator("input#newshare_conv_bday")).to_be_disabled()
+    page.click('#createeditsharescene button[data-name="cancel"]')
+
     # Close the share scene and verify the virtual bday calendar is now in the collections list
     page.click('#sharecollectionscene button[data-name="cancel"]')
     expect(page.locator("#sharecollectionscene")).to_be_hidden()

--- a/radicale/web/internal_data/js/scenes/CreateEditShareScene.js
+++ b/radicale/web/internal_data/js/scenes/CreateEditShareScene.js
@@ -427,6 +427,7 @@ export class CreateEditShareScene {
                     radio.value = opt;
                     radio.id = id;
                     radio.checked = (opt === initial_conversion);
+                    radio.disabled = this._edit;
                     radio.onchange = () => this._on_conversion_change();
 
                     let label = document.createElement("label");


### PR DESCRIPTION
The conversion type cannot be changed once a share is created, so disable the edit buttons.