### PR TITLE
Fix: text-match filter crashes on structured property (vCard N/ADR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.7.7.dev
 * Fix: time-range filter treated a VEVENT with a whole-day DURATION (e.g. P1D, P2D) as zero-length (timedelta.seconds instead of total_seconds), so such events were missing from calendar-query REPORT results
 * Fix: calendar-data expand (REPORT) left recurrence properties (e.g. RDATE) on the expanded single-occurrence VEVENTs; a single try/except around the sequential delattr() calls stopped at the first absent property (e.g. missing EXDATE), so later ones were never removed
+* Fix: text-match filter on a structured property (e.g. vCard N or ADR) crashed with HTTP 500 (AttributeError: 'Name'/'Address' object has no attribute 'lower') because vobject parses these into non-string objects; their text representation is now used
 
 ## 3.7.6
 * Extension: item verification on commandline

--- a/radicale/item/filter.py
+++ b/radicale/item/filter.py
@@ -578,6 +578,11 @@ def text_match(vobject_item: vobject.base.Component,
         match_type = filter_.get("match-type", match_type)
 
     def match(value: str) -> bool:
+        if not isinstance(value, str):
+            # Some properties (e.g. N and ADR in vCard) are parsed by vobject
+            # into structured objects instead of plain strings. Use their text
+            # representation so text-match doesn't crash with AttributeError.
+            value = str(value)
         value = value.lower()
         if match_type == "equals":
             return value == text

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -1458,6 +1458,18 @@ permissions: RrWw""")
     <C:text-match collation="i;unicode-casemap">test</C:text-match>
 </C:prop-filter>"""], "contact", test="allof")
 
+    def test_addressbook_prop_filter_structured(self) -> None:
+        """text-match on a structured property (N) that vobject parses into a
+        non-string value must not crash the REPORT."""
+        assert "/contacts.vcf/contact1.vcf" in self._test_filter(["""\
+<C:prop-filter name="N">
+    <C:text-match collation="i;unicode-casemap">contact</C:text-match>
+</C:prop-filter>"""], "contact")
+        assert "/contacts.vcf/contact1.vcf" not in self._test_filter(["""\
+<C:prop-filter name="N">
+    <C:text-match collation="i;unicode-casemap">nonexistent</C:text-match>
+</C:prop-filter>"""], "contact")
+
     def test_calendar_empty_filter(self) -> None:
         self._test_filter([""])
 


### PR DESCRIPTION
A CardDAV `addressbook-query` REPORT that applies a `text-match` prop-filter to a structured property such as `N` or `ADR` returned HTTP 500. vobject parses those into `Name`/`Address` objects rather than plain strings, so `text_match()` called `.lower()` on a non-string and raised `AttributeError` (surfaced as a 500 via `xml_report`'s exception wrapping).

Fix: coerce non-string property values to their text representation (`str(value)`, e.g. `"Dr John Q Doe Jr"`) before matching. String and list-valued (CATEGORIES/ORG) properties are unaffected. Added a regression test and a CHANGELOG entry.

Verified: the new test fails before the change (500 / `'Name' object has no attribute 'lower'`) and passes after; broader `addressbook`/`filter`/`text_match` tests (28) pass; flake8/isort/mypy clean.

_Prepared with AI assistance (Claude) and reviewed/verified by me._
