### PR TITLE
Fix: free-busy REPORT always fails with HTTP 400 when max_freebusy_occurrence is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.7.7.dev
+* Fix: free-busy REPORT always failed with HTTP 400 ("FREEBUSY occurrences limit of 0 hit") when [reporting] max_freebusy_occurrence is set to 0 (limit disabled), because the limit check did not honor the disabled limit
 * Fix: time-range filter treated a VEVENT with a whole-day DURATION (e.g. P1D, P2D) as zero-length (timedelta.seconds instead of total_seconds), so such events were missing from calendar-query REPORT results
 * Fix: calendar-data expand (REPORT) left recurrence properties (e.g. RDATE) on the expanded single-occurrence VEVENTs; a single try/except around the sequential delattr() calls stopped at the first absent property (e.g. missing EXDATE), so later ones were never removed
 * Fix: text-match filter on a structured property (e.g. vCard N or ADR) crashed with HTTP 500 (AttributeError: 'Name'/'Address' object has no attribute 'lower') because vobject parses these into non-string objects; their text representation is now used

--- a/radicale/app/report.py
+++ b/radicale/app/report.py
@@ -133,7 +133,7 @@ def free_busy_report(base_prefix: str, path: str, xml_request: Optional[ET.Eleme
                                                       time_range_element,
                                                       "VEVENT",
                                                       n=n_occurrences)
-        if len(occurrences) >= max_occurrence:
+        if max_occurrence > 0 and len(occurrences) >= max_occurrence:
             raise ValueError("FREEBUSY occurrences limit of {} hit"
                              .format(max_occurrence))
 

--- a/radicale/tests/test_base.py
+++ b/radicale/tests/test_base.py
@@ -2232,6 +2232,18 @@ permissions: RrWw""")
     <C:time-range start="20130901T140000Z" end="20130908T220000Z"/>
 </C:free-busy-query>""", 400, is_xml=False)
 
+        # Test max_freebusy_occurrence set to 0 (limit disabled)
+        self.configure({"reporting": {"max_freebusy_occurrence": 0}})
+        code, responses = self.report(calendar_path, """\
+<?xml version="1.0" encoding="utf-8" ?>
+<C:free-busy-query xmlns:C="urn:ietf:params:xml:ns:caldav">
+    <C:time-range start="20130901T140000Z" end="20130908T220000Z"/>
+</C:free-busy-query>""", 200, is_xml=False)
+        assert len(responses) == 1
+        vcalendar = list(responses.values())[0]
+        assert isinstance(vcalendar, vobject.base.Component)
+        assert len(vcalendar.vfreebusy_list) == 3
+
     def _report_sync_token(
             self, calendar_path: str, sync_token: Optional[str] = None, **kwargs
             ) -> Tuple[str, RESPONSES]:


### PR DESCRIPTION
**Problem**
With `[reporting] max_freebusy_occurrence = 0` (limit disabled), every `free-busy-query` REPORT on a calendar containing items fails with HTTP 400 and logs `FREEBUSY occurrences limit of 0 hit`.

**Cause**
`free_busy_report()` already treats `max_occurrence == 0` as "no limit" when fetching occurrences (`n_occurrences = 0` lets `time_range_fill()` return everything, see 408a03a3), but the subsequent check `if len(occurrences) >= max_occurrence:` is trivially true for `max_occurrence == 0`, so it always raises.

**Fix**
Skip the limit check when the limit is disabled (`max_occurrence > 0 and ...`), consistent with how `xml_report()` handles the same setting (`if max_occurrence and n_vevents > max_occurrence`). Behavior for positive limits is unchanged (the existing `max_freebusy_occurrence = 1` test still expects 400).

**Testing**
Extended `test_report_free_busy` with the `max_freebusy_occurrence = 0` case (expects 200 and the same 3 VFREEBUSY components as the default-config case). Fails before the fix, passes after; full `test_base.py` suite green (152 passed); flake8/isort/mypy clean on touched files. CHANGELOG entry added under 3.7.7.dev.

Disclosure: this fix was prepared with the assistance of an AI tool (Claude Code) and reviewed/verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
