### PR TITLE
Add openssh-client to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 RUN addgroup -g 1000 radicale \
     && adduser radicale --home /var/lib/radicale --system --uid 1000 --disabled-password -G radicale \
-    && apk add --no-cache ca-certificates openssl curl git
+    && apk add --no-cache ca-certificates openssl curl git openssh-client
 
 COPY --chown=radicale:radicale --from=builder /app/venv /app
 


### PR DESCRIPTION
This PR adds the openssh-client package to the Docker image, enabling Radicale hooks to synchronize with Git repositories over SSH.