### PR TITLE
Add Alpine packages to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 RUN addgroup -g 1000 radicale \
     && adduser radicale --home /var/lib/radicale --system --uid 1000 --disabled-password -G radicale \
-    && apk add --no-cache ca-certificates openssl curl git
+    && apk add --no-cache ca-certificates openssl curl git openssh-client
 
 COPY --chown=radicale:radicale --from=builder /app/venv /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 RUN addgroup -g 1000 radicale \
     && adduser radicale --home /var/lib/radicale --system --uid 1000 --disabled-password -G radicale \
-    && apk add --no-cache ca-certificates openssl curl git openssh-client
+    && apk add --no-cache ca-certificates openssl curl git openssh-client apache2-utils
 
 COPY --chown=radicale:radicale --from=builder /app/venv /app
 


### PR DESCRIPTION
This PR adds the apache2-utils and openssh-client packages to the Docker image. Both packages are required to:

1. Use a htpasswd file with encryption 
2. Use Radicale hooks to synchronize with Git over SSH