### PR TITLE
Minor fixes extensions related to group membership based collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Extension: [auth] type "pam": set groups of user to be used later
 * Adjustment: reject usernames starting or ending with "@" or having more than one "@"
 * Adjustment: reject usernames containing ":"
+* Add: [group] group_collections_folder replacing hardcoded "GROUPS"
 
 ## 3.7.8
 * Fix: time-range filter on a VTODO having DTSTART/DUE and also CREATED/COMPLETED used the CREATED->COMPLETED duration instead of the DTSTART->DUE one, so completed tasks were missing from (or wrongly returned by) calendar-query REPORT results

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1540,6 +1540,16 @@ Enable caching of htgroup file based on size and mtime_ns
 
 Default: `False`
 
+##### group_collections_folder
+
+_(>= 3.8.0)_
+
+Folder under *collection_root_folder* containing collections of base64 encoded group names _(>= 3.3.0)_
+
+Default: `GROUPS`
+
+Unset if not required or unwanted
+
 #### [rights]
 
 ##### type

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1550,6 +1550,8 @@ Default: `GROUPS`
 
 Unset if not required or unwanted
 
+Note: only supported on case-sensitive file systems
+
 #### [rights]
 
 ##### type

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1257,11 +1257,6 @@ For DN-valued attributes, the value of the RDN is used to determine the group na
 The implementation also supports non-DN-valued attributes: their values are taken directly.
 
 The user's group names can be used later to define rights.
-They also give you access to the group calendars, if those exist.
-* Group calendars are placed directly under *collection_root_folder*`/GROUPS/`
-  with the base64-encoded group name as the calendar folder name.
-* Group calendar folders are not created automatically.
-  This must be done manually. In the [LDAP-authentication section of Radicale's wiki](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create a group calendar.
 
 Default: (unset)
 
@@ -1503,6 +1498,12 @@ Default: `False`
 #### [group]
 
 _(>= 3.8.0)_
+
+User's group membership also give you access to group collections, if those exist.
+* Group collections are placed directly under *collection_root_folder*`/GROUPS/`
+  with the base64-encoded group name as the collection folder name.
+* Group collections folders are not created automatically.
+  This must be done manually. In the [LDAP-authentication section of Radicale's wiki](https://github.com/Kozea/Radicale/wiki/LDAP-authentication) you can find a script to create a group calendar.
 
 ##### type
 

--- a/config
+++ b/config
@@ -223,6 +223,9 @@ type = none
 # Enable caching of htgroup file based on size and mtime_ns
 #htgroup_cache = False
 
+# Folder under *collection_root_folder* containing collections of base64 encoded group names
+# group_collections_folder = "GROUPS"
+
 
 [rights]
 

--- a/radicale/app/mkcalendar.py
+++ b/radicale/app/mkcalendar.py
@@ -71,6 +71,7 @@ class ApplicationPartMkcalendar(ApplicationBase):
             parent_path = pathutils.parent_path(path)
             parent_item = next(iter(self._storage.discover(parent_path)), None)
             if not parent_item:
+                logger.error("Failed MKCALENDAR request on %r: parent folder is not existing %r", path, parent_path)
                 return httputils.CONFLICT
             if (not isinstance(parent_item, storage.BaseCollection) or
                     parent_item.tag):

--- a/radicale/app/propfind.py
+++ b/radicale/app/propfind.py
@@ -640,11 +640,11 @@ class ApplicationPartPropfind(ApplicationBase):
                     allowed_items.append((item, permission, raw_permissions, None))
         if self._sharing._enabled:
             if http_depth == "1":
-                logger.trace("PROPFIND: get shared collections")
                 # check for shared collections related to user, Enabled and not Hidden
                 user_lookup = user
                 if self._rights._user_groups is not None and len(self._rights._user_groups) > 0:
                     user_lookup += sharing.SHARING_SEPARATOR_GROUP + ','.join(self._rights._user_groups)
+                logger.debug("PROPFIND: lookup shared collections for user=%r", user_lookup)
                 collections_share_list = self._sharing.sharing_collection_list(User=user_lookup, Enabled=True, Hidden=False)
                 if collections_share_list:
                     for share in collections_share_list:
@@ -655,9 +655,9 @@ class ApplicationPartPropfind(ApplicationBase):
                         logger.trace("PROPFIND: test shared collection: PathOrToken=%r PathMapped=%r Owner=%r Permissions=%r", c_share, c_path, c_user, c_permissions_filter)
                         c_access = Access(self._rights, c_user, c_path, c_permissions_filter)
                         if not c_access.check("r"):
-                            logger.trace("PROPFIND: skip shared collection: PathOrToken=%r PathMapped=%r Owner=%r Permissions=%r (permissions not matching)", c_share, c_path, c_user, c_permissions_filter)
+                            logger.debug("PROPFIND: skip shared collection: PathOrToken=%r PathMapped=%r Owner=%r Permissions=%r (permissions not matching)", c_share, c_path, c_user, c_permissions_filter)
                             continue
-                        logger.trace("PROPFIND: append shared collection: PathOrToken=%r PathMapped=%r Owner=%r Permissions=%r", c_share, c_path, c_user, c_permissions_filter)
+                        logger.debug("PROPFIND: append shared collection: PathOrToken=%r PathMapped=%r Owner=%r Permissions=%r", c_share, c_path, c_user, c_permissions_filter)
                         with self._storage.acquire_lock("r", c_user):
                             c_items_iter = iter(self._storage.discover(c_path, "0"))
                             c_allowed_items = list(self._collect_allowed_items(c_items_iter, c_user))

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -498,6 +498,10 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "value": "False",
             "help": "enable caching of htgroup file",
             "type": bool}),
+        ("group_collections_folder", {
+            "value": "GROUPS",
+            "help": "folder under collection_root_folder containing collections of base64 encoded group names",
+            "type": str}),
     ])),
     ("rights", OrderedDict([
         ("type", {

--- a/radicale/sharing/csv.py
+++ b/radicale/sharing/csv.py
@@ -155,7 +155,7 @@ class Sharing(sharing.BaseSharing):
         result = []
 
         with self._storage.acquire_lock("r", path=self._sharing_db_file):
-            logger.trace("sharing/list/called: ShareType=%r OwnerOrUser=%r User=%r PathOrToken=%r PathMapped=%r EnabledByOwner=%s EnabledByUser=%s HiddenByOwner=%s HiddenByUser=%s Conversion=%r", ShareType, OwnerOrUser, User, PathOrToken, PathMapped, EnabledByOwner, EnabledByUser, HiddenByOwner, HiddenByUser, Conversion)
+            logger.trace("sharing/%s/list: OwnerOrUser=%r User=%r PathOrToken=%r PathMapped=%r EnabledByOwner=%s EnabledByUser=%s HiddenByOwner=%s HiddenByUser=%s Conversion=%r", ShareType, OwnerOrUser, User, PathOrToken, PathMapped, EnabledByOwner, EnabledByUser, HiddenByOwner, HiddenByUser, Conversion)
 
             for row in self._sharing_cache:
                 index += 1

--- a/radicale/sharing/files.py
+++ b/radicale/sharing/files.py
@@ -100,7 +100,7 @@ class Sharing(sharing.BaseSharing):
                 return None
             else:
                 # check by group
-                logger.trace("sharing/%s/get: no direct share found, run through filtered list")
+                logger.trace("sharing/%s/get: no direct share found, run through filtered list", ShareType)
                 for row in self.database_list_sharing(ShareType=ShareType, PathOrToken=PathOrToken, User=User):
                     if OnlyEnabled is True and row['EnabledByOwner'] is False:
                         continue
@@ -154,7 +154,7 @@ class Sharing(sharing.BaseSharing):
                 Conversion = row['Conversion']
             if 'Actions' in row:
                 Actions = row['Actions']
-            logger.trace("sharing: map %r to %r (Owner=%r User=%r Permissions=%r Hidden=%s Properties=%r)", PathOrToken, PathMapped, Owner, UserShare, Permissions, Hidden, Properties)
+            logger.trace("sharing/%s/get: map %r to %r (Owner=%r User=%r Permissions=%r Hidden=%s Properties=%r)", ShareType, PathOrToken, PathMapped, Owner, UserShare, Permissions, Hidden, Properties)
             return {
                     "mapped": True,
                     "ShareType": ShareType,
@@ -188,7 +188,7 @@ class Sharing(sharing.BaseSharing):
         """ retrieve sharing """
         result = []
 
-        logger.trace("sharing/list/called: ShareType=%r OwnerOrUser=%r User=%r PathOrToken=%r PathMapped=%r EnabledByOwner=%s EnabledByUser=%s HiddenByOwner=%s HiddenByUser=%s Conversion=%r", ShareType, OwnerOrUser, User, PathOrToken, PathMapped, EnabledByOwner, EnabledByUser, HiddenByOwner, HiddenByUser, Conversion)
+        logger.trace("sharing/%s/list: OwnerOrUser=%r User=%r PathOrToken=%r PathMapped=%r EnabledByOwner=%s EnabledByUser=%s HiddenByOwner=%s HiddenByUser=%s Conversion=%r", ShareType, OwnerOrUser, User, PathOrToken, PathMapped, EnabledByOwner, EnabledByUser, HiddenByOwner, HiddenByUser, Conversion)
 
         for _ShareType in sharing.SHARE_TYPES_V1:
             if ShareType is not None and _ShareType != ShareType:

--- a/radicale/storage/multifilesystem/__init__.py
+++ b/radicale/storage/multifilesystem/__init__.py
@@ -214,3 +214,4 @@ class Storage(
                 logger.warning("Storage cache subfolder: %r does not exist, creating now", self._get_collection_cache_folder())
                 self._makedirs_synced(self._get_collection_cache_folder())
             logger.info("Storage cache subfolder permissions: %s", pathutils.path_permissions_as_string(self._get_collection_cache_folder()))
+        logger.info("Group collections folder: %r", self._group_collections_folder)

--- a/radicale/storage/multifilesystem/__init__.py
+++ b/radicale/storage/multifilesystem/__init__.py
@@ -2,7 +2,7 @@
 # Copyright © 2014 Jean-Marc Martins
 # Copyright © 2012-2017 Guillaume Ayoub
 # Copyright © 2017-2021 Unrud <unrud@outlook.com>
-# Copyright © 2024-2025 Peter Bieringer <pb@bieringer.de>
+# Copyright © 2024-2026 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/storage/multifilesystem/__init__.py
+++ b/radicale/storage/multifilesystem/__init__.py
@@ -214,4 +214,8 @@ class Storage(
                 logger.warning("Storage cache subfolder: %r does not exist, creating now", self._get_collection_cache_folder())
                 self._makedirs_synced(self._get_collection_cache_folder())
             logger.info("Storage cache subfolder permissions: %s", pathutils.path_permissions_as_string(self._get_collection_cache_folder()))
-        logger.info("Group collections folder: %r", self._group_collections_folder)
+        if is_collision_free_case_sensitive or self._group_collections_folder is None or len(self._group_collections_folder) == 0:
+            logger.info("Group collections folder: %r", self._group_collections_folder)
+        else:
+            logger.warning("Group collections folder disabled, file system is not case-sensitive: %r", self._group_collections_folder)
+            self._group_collections_folder = ""

--- a/radicale/storage/multifilesystem/base.py
+++ b/radicale/storage/multifilesystem/base.py
@@ -83,6 +83,7 @@ class StorageBase(storage.BaseStorage):
     _folder_umask: str
     _config_umask: int
     _max_resource_size: int
+    _group_collections_folder: str
 
     def __init__(self, configuration: config.Configuration) -> None:
         super().__init__(configuration)
@@ -107,6 +108,7 @@ class StorageBase(storage.BaseStorage):
         self._max_resource_size = configuration.get(
             "server", "max_resource_size")
         self._max_vevent_rrule_occurrence = configuration.get("server", "max_vevent_rrule_occurrence")
+        self._group_collections_folder = configuration.get("group", "group_collections_folder")
 
     def _get_collection_root_folder(self) -> str:
         return os.path.join(self._filesystem_folder, "collection-root")

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -110,7 +110,7 @@ class StoragePartDiscover(StorageBase):
                     cast(multifilesystem.Storage, self), child_path)
         for group in user_groups:
             href = base64.b64encode(group.encode('utf-8')).decode('ascii')
-            logger.debug(f"searching for group calendar {group} {href}")
+            logger.debug(f"searching for group calendar '{group}' '{href}'")
             sane_child_path = f"GROUPS/{href}"
             if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
                 continue

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -110,22 +110,25 @@ class StoragePartDiscover(StorageBase):
             with child_context_manager(sane_child_path, None):
                 yield self._collection_class(
                     cast(multifilesystem.Storage, self), child_path)
-        if self._group_collections_folder is None or len(self._group_collections_folder) == 0:
-            logger.trace("searching for collection by user group skipped because base folder is not defined")
-        else:
-            logger.trace("searching for collection by user group in folder: %r", self._group_collections_folder)
-            if os.path.isdir(pathutils.path_to_filesystem(folder, self._group_collections_folder, self._is_collision_free)):
-                for group in user_groups:
-                    href = base64.b64encode(group.encode('utf-8')).decode('ascii')
-                    sane_child_path = os.path.join(self._group_collections_folder, href)
-                    logger.debug("searching for collection by user group=%r path=%r", group, sane_child_path)
-                    if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
-                        logger.trace("searching for collection by user group=%r path=%r is not existing (skip)", group, sane_child_path)
-                        continue
-                    child_path = "/" + self._group_collections_folder + "/" + href + "/"
-                    logger.trace("searching for collection by user group with child_path: %r", child_path)
-                    with child_context_manager(sane_child_path, None):
-                        yield self._collection_class(
-                            cast(multifilesystem.Storage, self), child_path)
+        if len(user_groups) > 0:
+            if self._group_collections_folder is None or len(self._group_collections_folder) == 0:
+                logger.trace("searching for collection by user group skipped because base folder is not defined")
             else:
-                logger.trace("searching for collection by user group skipped because base folder is not existing: %r", self._group_collections_folder)
+                logger.trace("searching for collection by user group in folder: %r", self._group_collections_folder)
+                if os.path.isdir(pathutils.path_to_filesystem(folder, self._group_collections_folder, self._is_collision_free)):
+                    for group in user_groups:
+                        href = base64.b64encode(group.encode('utf-8')).decode('ascii')
+                        sane_child_path = os.path.join(self._group_collections_folder, href)
+                        logger.debug("searching for collection by user group=%r path=%r", group, sane_child_path)
+                        if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
+                            logger.trace("searching for collection by user group=%r path=%r is not existing (skip)", group, sane_child_path)
+                            continue
+                        child_path = "/" + self._group_collections_folder + "/" + href + "/"
+                        logger.trace("searching for collection by user group with child_path: %r", child_path)
+                        with child_context_manager(sane_child_path, None):
+                            yield self._collection_class(
+                                cast(multifilesystem.Storage, self), child_path)
+                else:
+                    logger.trace("searching for collection by user group skipped because base folder is not existing: %r", self._group_collections_folder)
+        else:
+            logger.trace("searching for collection by user group not required as user has no groups")

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -108,13 +108,16 @@ class StoragePartDiscover(StorageBase):
             with child_context_manager(sane_child_path, None):
                 yield self._collection_class(
                     cast(multifilesystem.Storage, self), child_path)
-        for group in user_groups:
-            href = base64.b64encode(group.encode('utf-8')).decode('ascii')
-            sane_child_path = f"GROUPS/{href}"
-            logger.debug("searching for collection by user group=%r path=%r", group, sane_child_path)
-            if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
-                continue
-            child_path = f"/GROUPS/{href}/"
-            with child_context_manager(sane_child_path, None):
-                yield self._collection_class(
-                    cast(multifilesystem.Storage, self), child_path)
+        if os.path.isdir(pathutils.path_to_filesystem(folder, "GROUPS", self._is_collision_free)):
+            for group in user_groups:
+                href = base64.b64encode(group.encode('utf-8')).decode('ascii')
+                sane_child_path = f"GROUPS/{href}"
+                logger.debug("searching for collection by user group=%r path=%r", group, sane_child_path)
+                if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
+                    continue
+                child_path = f"/GROUPS/{href}/"
+                with child_context_manager(sane_child_path, None):
+                    yield self._collection_class(
+                        cast(multifilesystem.Storage, self), child_path)
+        else:
+            logger.trace("searching for collection by user group skipped because base folder is not existing: %r", "GROUPS")

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -110,8 +110,8 @@ class StoragePartDiscover(StorageBase):
                     cast(multifilesystem.Storage, self), child_path)
         for group in user_groups:
             href = base64.b64encode(group.encode('utf-8')).decode('ascii')
-            logger.debug(f"searching for group calendar '{group}' '{href}'")
             sane_child_path = f"GROUPS/{href}"
+            logger.debug("searching for collection by user group=%r path=%r", group, sane_child_path)
             if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
                 continue
             child_path = f"/GROUPS/{href}/"

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -108,16 +108,22 @@ class StoragePartDiscover(StorageBase):
             with child_context_manager(sane_child_path, None):
                 yield self._collection_class(
                     cast(multifilesystem.Storage, self), child_path)
-        if os.path.isdir(pathutils.path_to_filesystem(folder, "GROUPS", self._is_collision_free)):
-            for group in user_groups:
-                href = base64.b64encode(group.encode('utf-8')).decode('ascii')
-                sane_child_path = f"GROUPS/{href}"
-                logger.debug("searching for collection by user group=%r path=%r", group, sane_child_path)
-                if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
-                    continue
-                child_path = f"/GROUPS/{href}/"
-                with child_context_manager(sane_child_path, None):
-                    yield self._collection_class(
-                        cast(multifilesystem.Storage, self), child_path)
+        if self._group_collections_folder is None or len(self._group_collections_folder) == 0:
+            logger.trace("searching for collection by user group skipped because base folder is not defined")
         else:
-            logger.trace("searching for collection by user group skipped because base folder is not existing: %r", "GROUPS")
+            logger.trace("searching for collection by user group in folder: %r", self._group_collections_folder)
+            if os.path.isdir(pathutils.path_to_filesystem(folder, self._group_collections_folder, self._is_collision_free)):
+                for group in user_groups:
+                    href = base64.b64encode(group.encode('utf-8')).decode('ascii')
+                    sane_child_path = os.path.join(self._group_collections_folder, href)
+                    logger.debug("searching for collection by user group=%r path=%r", group, sane_child_path)
+                    if not os.path.isdir(pathutils.path_to_filesystem(folder, sane_child_path, self._is_collision_free)):
+                        logger.trace("searching for collection by user group=%r path=%r is not existing (skip)", group, sane_child_path)
+                        continue
+                    child_path = "/" + self._group_collections_folder + "/" + href + "/"
+                    logger.trace("searching for collection by user group with child_path: %r", child_path)
+                    with child_context_manager(sane_child_path, None):
+                        yield self._collection_class(
+                            cast(multifilesystem.Storage, self), child_path)
+            else:
+                logger.trace("searching for collection by user group skipped because base folder is not existing: %r", self._group_collections_folder)

--- a/radicale/storage/multifilesystem/discover.py
+++ b/radicale/storage/multifilesystem/discover.py
@@ -2,6 +2,8 @@
 # Copyright © 2014 Jean-Marc Martins
 # Copyright © 2012-2017 Guillaume Ayoub
 # Copyright © 2017-2018 Unrud <unrud@outlook.com>
+# Copyright © 2024-2024 Peter Varkoly
+# Copyright © 2026-2026 Peter Bieringer <pb@bieringer.de>
 #
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/radicale/tests/test_group.py
+++ b/radicale/tests/test_group.py
@@ -23,10 +23,12 @@ import base64
 import logging
 import os
 import sys
+import tempfile
 
 import pytest
 
 import radicale
+from radicale import pathutils
 from radicale.tests import BaseTest
 from radicale.tests.helpers import get_file_content
 
@@ -190,6 +192,7 @@ permissions: r
             else:
                 pass
 
+    @pytest.mark.skipif(not pathutils.path_is_collision_free_case_sensitive(tempfile.mkdtemp()), reason="TEMP is not case sensitive")
     def test_static_group_collection_discovery_by_user_group_missing_base_folder(self) -> None:
         """static group collection discovery by user group (base64 encoded) where base folder is missing."""
         self.configure({"auth": {"type": "htpasswd",
@@ -222,6 +225,7 @@ permissions: r
         assert path_user1 in responses
         assert path_static_group1 not in responses
 
+    @pytest.mark.skipif(not pathutils.path_is_collision_free_case_sensitive(tempfile.mkdtemp()), reason="TEMP is not case sensitive")
     def test_static_group_collection_discovery_by_user_group_success(self) -> None:
         """static group collection discovery by user group (base64 encoded)."""
         self.configure({"auth": {"type": "htpasswd",
@@ -274,6 +278,7 @@ permissions: r
         logging.info("\n*** GET from group collection as user1")
         self.get(path_static_group1 + "event1.ics", login="user1:user1pw")
 
+    @pytest.mark.skipif(not pathutils.path_is_collision_free_case_sensitive(tempfile.mkdtemp()), reason="TEMP is not case sensitive")
     def test_static_group_collection_discovery_by_user_group_custom_folder(self) -> None:
         """static group collection discovery by user group (base64 encoded)."""
         self.configure({"auth": {"type": "htpasswd",
@@ -328,6 +333,7 @@ permissions: r
         logging.info("\n*** GET from group collection as user1")
         self.get(path_static_group1 + "event1.ics", login="user1:user1pw")
 
+    @pytest.mark.skipif(not pathutils.path_is_collision_free_case_sensitive(tempfile.mkdtemp()), reason="TEMP is not case sensitive")
     def test_static_group_collection_discovery_by_user_group_disabled_folder(self) -> None:
         """static group collection discovery by user group (base64 encoded)."""
         self.configure({"auth": {"type": "htpasswd",
@@ -363,3 +369,40 @@ permissions: r
         # get item as user1 -> not found
         logging.info("\n*** GET from group collection as user1")
         self.get(path_static_group1 + "event1.ics", login="user1:user1pw", check=404)
+
+    @pytest.mark.skipif(pathutils.path_is_collision_free_case_sensitive(tempfile.mkdtemp()), reason="TEMP is case sensitive")
+    def test_static_group_collection_discovery_by_user_group_not_case_sensitive(self) -> None:
+        """static group collection discovery by user group (base64 encoded)."""
+        self.configure({"auth": {"type": "htpasswd",
+                                 "htpasswd_filename": self.htpasswd_file_path,
+                                 "htpasswd_encryption": "plain"},
+                        "group": {"type": "htgroup",
+                                  "htgroup_filename": self.htgroup_file_path,
+                                  "group_collections_folder": "",
+                                  },
+                        "logging": {"request_header_on_debug": "False",
+                                    "response_content_on_debug": "True",
+                                    "request_content_on_debug": "True"},
+                        "rights": {"type": "from_file",
+                                   "file": self.rights_file_path,
+                                   }})
+
+        path_static_group1 = "/GROUPS/" + base64.b64encode("group1".encode('utf-8')).decode('ascii') + "/"
+
+        path_static_group1 = "/GROUPS/" + base64.b64encode("group1".encode('utf-8')).decode('ascii') + "/"
+        os.mkdir(os.path.join(self.colpath, "collection-root", "GROUPS"))
+        self.mkcalendar(path_static_group1, login="owner:ownerpw")
+
+        logging.info("\n*** prepare user folder")
+        path_user1 = "/user1/calendarU1.ics/"
+        self.mkcalendar(path_user1, login="user1:user1pw")
+
+        # verify PROPFIND as user1 in list
+        logging.info("\n*** PROPFIND collection DEPTH=1 user1")
+        _, responses = self.propfind("/user1/", """\
+<?xml version="1.0" encoding="utf-8"?>
+<propfind xmlns="DAV:">
+<calendar-home-set xmlns="urn:ietf:params:xml:ns:caldav" />
+</propfind>""", login="user1:user1pw", HTTP_DEPTH="1")
+        assert path_user1 in responses
+        assert path_static_group1 not in responses

--- a/radicale/tests/test_group.py
+++ b/radicale/tests/test_group.py
@@ -19,6 +19,7 @@ Radicale tests related to group lookup.
 
 """
 
+import base64
 import logging
 import os
 import sys
@@ -27,14 +28,53 @@ import pytest
 
 import radicale
 from radicale.tests import BaseTest
+from radicale.tests.helpers import get_file_content
 
 
 class TestBaseGroupRequests(BaseTest):
-    """Tests basic requests with group lookup.
+    """Tests basic requests with group lookup."""
+    def setup_method(self) -> None:
+        BaseTest.setup_method(self)
+        self.htpasswd_file_path = os.path.join(self.colpath, ".htpasswd")
+        self.htgroup_file_path = os.path.join(self.colpath, ".htgroup")
+        htpasswd = ["owner:ownerpw",
+                    "user1:user1pw",
+                    "user2:user2pw",
+                    ]
+        htgroup = ["group1:user1",
+                   "group2:user2",
+                   "admins:owner",
+                   ]
+        htpasswd_content = "\n".join(htpasswd)
+        htgroup_content = "\n".join(htgroup)
+        with open(self.htpasswd_file_path, "w") as f:
+            f.write(htpasswd_content)
+        with open(self.htgroup_file_path, "w") as f:
+            f.write(htgroup_content)
+        self.rights_file_path = os.path.join(self.colpath, "rights")
+        with open(self.rights_file_path, "w") as f:
+            f.write("""\
+# let user create its own base folder
+[principal]
+user: .+
+collection: {user}
+permissions: RW
 
-    We should setup auth for each type before creating the Application object.
+# let user create its own collections
+[collections]
+user: .+
+collection: {user}/[^/]+
+permissions: rw
 
-    """
+[calendarsWriter]
+groups: admins
+collection: GROUPS/[^/]+
+permissions: rw
+
+[calendarsReader]
+user: .+
+collection: GROUPS/[^/]+
+permissions: r""")
 
     def _test_htgroup(self, htpasswd_content: str, htgroup_content, check: int = 207) -> None:
         """Test htpasswd authentication with user "tmp" and password "bepo" for
@@ -138,3 +178,87 @@ class TestBaseGroupRequests(BaseTest):
                 raise
             else:
                 pass
+
+    def test_static_group_collection_discovery_by_user_group_missing_base_folder(self) -> None:
+        """static group collection discovery by user group (base64 encoded) where base folder is missing."""
+        self.configure({"auth": {"type": "htpasswd",
+                                 "htpasswd_filename": self.htpasswd_file_path,
+                                 "htpasswd_encryption": "plain"},
+                        "group": {"type": "htgroup",
+                                  "htgroup_filename": self.htgroup_file_path},
+                        "logging": {"request_header_on_debug": "False",
+                                    "response_content_on_debug": "True",
+                                    "request_content_on_debug": "True"},
+                        "rights": {"type": "from_file",
+                                   "file": self.rights_file_path,
+                                   }})
+
+        logging.info("\n*** prepare GROUPS folder")
+
+        path_static_group1 = "/GROUPS/" + base64.b64encode("group1".encode('utf-8')).decode('ascii') + "/"
+
+        logging.info("\n*** prepare user folder")
+        path_user1 = "/user1/calendarU1.ics/"
+        self.mkcalendar(path_user1, login="user1:user1pw")
+
+        # verify PROPFIND as user1 in list
+        logging.info("\n*** PROPFIND collection DEPTH=1 user1")
+        _, responses = self.propfind("/user1/", """\
+<?xml version="1.0" encoding="utf-8"?>
+<propfind xmlns="DAV:">
+<calendar-home-set xmlns="urn:ietf:params:xml:ns:caldav" />
+</propfind>""", login="user1:user1pw", HTTP_DEPTH="1")
+        assert path_user1 in responses
+        assert path_static_group1 not in responses
+
+    def test_static_group_collection_discovery_by_user_group_success(self) -> None:
+        """static group collection discovery by user group (base64 encoded)."""
+        self.configure({"auth": {"type": "htpasswd",
+                                 "htpasswd_filename": self.htpasswd_file_path,
+                                 "htpasswd_encryption": "plain"},
+                        "group": {"type": "htgroup",
+                                  "htgroup_filename": self.htgroup_file_path},
+                        "logging": {"request_header_on_debug": "False",
+                                    "response_content_on_debug": "True",
+                                    "request_content_on_debug": "True"},
+                        "rights": {"type": "from_file",
+                                   "file": self.rights_file_path,
+                                   }})
+
+        logging.info("\n*** prepare GROUPS folder")
+        path_static_group1 = "/GROUPS/" + base64.b64encode("group1".encode('utf-8')).decode('ascii') + "/"
+        self.mkcalendar(path_static_group1, login="owner:ownerpw", check=409)
+
+        # create GROUPS folder
+        os.mkdir(os.path.join(self.colpath, "collection-root", "GROUPS"))
+
+        # try again
+        self.mkcalendar(path_static_group1, login="owner:ownerpw")
+
+        logging.info("\n*** prepare user folder")
+        path_user1 = "/user1/calendarU1.ics/"
+        self.mkcalendar(path_user1, login="user1:user1pw")
+
+        # try upload item as owner -> ok (w permission defined)
+        logging.info("\n*** PUT to path as owner -> 201")
+        event = get_file_content("event1.ics")
+        self.put(path_static_group1, event, login="owner:ownerpw")
+
+        # verify PROPFIND as user1 in list
+        logging.info("\n*** PROPFIND collection DEPTH=1 user1")
+        _, responses = self.propfind("/user1/", """\
+<?xml version="1.0" encoding="utf-8"?>
+<propfind xmlns="DAV:">
+<calendar-home-set xmlns="urn:ietf:params:xml:ns:caldav" />
+</propfind>""", login="user1:user1pw", HTTP_DEPTH="1")
+        assert path_user1 in responses
+        assert path_static_group1 in responses
+
+        # try upload item as user1 -> fail (w permission missing)
+        logging.info("\n*** PUT to group collection as user1 -> 403")
+        event = get_file_content("event1.ics")
+        self.put(path_static_group1, event, login="user1:user1pw", check=403)
+
+        # get item as user1 -> success
+        logging.info("\n*** GET from group collection as user1")
+        self.get(path_static_group1 + "event1.ics", login="user1:user1pw")

--- a/radicale/tests/test_group.py
+++ b/radicale/tests/test_group.py
@@ -74,7 +74,18 @@ permissions: rw
 [calendarsReader]
 user: .+
 collection: GROUPS/[^/]+
-permissions: r""")
+permissions: r
+
+[calendarsWriterCustom]
+groups: admins
+collection: MYGROUPS/[^/]+
+permissions: rw
+
+[calendarsReaderCustom]
+user: .+
+collection: MYGROUPS/[^/]+
+permissions: r
+""")
 
     def _test_htgroup(self, htpasswd_content: str, htgroup_content, check: int = 207) -> None:
         """Test htpasswd authentication with user "tmp" and password "bepo" for
@@ -262,3 +273,93 @@ permissions: r""")
         # get item as user1 -> success
         logging.info("\n*** GET from group collection as user1")
         self.get(path_static_group1 + "event1.ics", login="user1:user1pw")
+
+    def test_static_group_collection_discovery_by_user_group_custom_folder(self) -> None:
+        """static group collection discovery by user group (base64 encoded)."""
+        self.configure({"auth": {"type": "htpasswd",
+                                 "htpasswd_filename": self.htpasswd_file_path,
+                                 "htpasswd_encryption": "plain"},
+                        "group": {"type": "htgroup",
+                                  "htgroup_filename": self.htgroup_file_path,
+                                  "group_collections_folder": "MYGROUPS",
+                                  },
+                        "logging": {"request_header_on_debug": "False",
+                                    "response_content_on_debug": "True",
+                                    "request_content_on_debug": "True"},
+                        "rights": {"type": "from_file",
+                                   "file": self.rights_file_path,
+                                   }})
+
+        logging.info("\n*** prepare MYGROUPS folder")
+        path_static_group1 = "/MYGROUPS/" + base64.b64encode("group1".encode('utf-8')).decode('ascii') + "/"
+        self.mkcalendar(path_static_group1, login="owner:ownerpw", check=409)
+
+        # create GROUPS folder
+        os.mkdir(os.path.join(self.colpath, "collection-root", "MYGROUPS"))
+
+        # try again
+        self.mkcalendar(path_static_group1, login="owner:ownerpw")
+
+        logging.info("\n*** prepare user folder")
+        path_user1 = "/user1/calendarU1.ics/"
+        self.mkcalendar(path_user1, login="user1:user1pw")
+
+        # try upload item as owner -> ok (w permission defined)
+        logging.info("\n*** PUT to path as owner -> 201")
+        event = get_file_content("event1.ics")
+        self.put(path_static_group1, event, login="owner:ownerpw")
+
+        # verify PROPFIND as user1 in list
+        logging.info("\n*** PROPFIND collection DEPTH=1 user1")
+        _, responses = self.propfind("/user1/", """\
+<?xml version="1.0" encoding="utf-8"?>
+<propfind xmlns="DAV:">
+<calendar-home-set xmlns="urn:ietf:params:xml:ns:caldav" />
+</propfind>""", login="user1:user1pw", HTTP_DEPTH="1")
+        assert path_user1 in responses
+        assert path_static_group1 in responses
+
+        # try upload item as user1 -> fail (w permission missing)
+        logging.info("\n*** PUT to group collection as user1 -> 403")
+        event = get_file_content("event1.ics")
+        self.put(path_static_group1, event, login="user1:user1pw", check=403)
+
+        # get item as user1 -> success
+        logging.info("\n*** GET from group collection as user1")
+        self.get(path_static_group1 + "event1.ics", login="user1:user1pw")
+
+    def test_static_group_collection_discovery_by_user_group_disabled_folder(self) -> None:
+        """static group collection discovery by user group (base64 encoded)."""
+        self.configure({"auth": {"type": "htpasswd",
+                                 "htpasswd_filename": self.htpasswd_file_path,
+                                 "htpasswd_encryption": "plain"},
+                        "group": {"type": "htgroup",
+                                  "htgroup_filename": self.htgroup_file_path,
+                                  "group_collections_folder": "",
+                                  },
+                        "logging": {"request_header_on_debug": "False",
+                                    "response_content_on_debug": "True",
+                                    "request_content_on_debug": "True"},
+                        "rights": {"type": "from_file",
+                                   "file": self.rights_file_path,
+                                   }})
+
+        path_static_group1 = "/GROUPS/" + base64.b64encode("group1".encode('utf-8')).decode('ascii') + "/"
+
+        logging.info("\n*** prepare user folder")
+        path_user1 = "/user1/calendarU1.ics/"
+        self.mkcalendar(path_user1, login="user1:user1pw")
+
+        # verify PROPFIND as user1 in list
+        logging.info("\n*** PROPFIND collection DEPTH=1 user1")
+        _, responses = self.propfind("/user1/", """\
+<?xml version="1.0" encoding="utf-8"?>
+<propfind xmlns="DAV:">
+<calendar-home-set xmlns="urn:ietf:params:xml:ns:caldav" />
+</propfind>""", login="user1:user1pw", HTTP_DEPTH="1")
+        assert path_user1 in responses
+        assert path_static_group1 not in responses
+
+        # get item as user1 -> not found
+        logging.info("\n*** GET from group collection as user1")
+        self.get(path_static_group1 + "event1.ics", login="user1:user1pw", check=404)

--- a/rights
+++ b/rights
@@ -50,7 +50,7 @@
 
 # Allow reading and writing calendars and address books that are direct
 # children of the principal collection
-#[calendars]
+#[calendars-addressbooks]
 #user: .+
 #collection: {user}/[^/]+
 #permissions: rw
@@ -67,7 +67,7 @@
 
 # Allow reading all calendars and address books that are direct children of any
 # principal collection
-#[read-all-calendars]
+#[read-all-calendars-addressbooks]
 #user: .+
 #collection: [^/]+/[^/]+
 #permissions: r
@@ -83,7 +83,7 @@
 
 # Allow reading and writing all calendars and address books that are direct
 # children of any principal collection
-#[calendars]
+#[calendars-addressbooks]
 #user: .+
 #collection: [^/]+/[^/]+
 #permissions: rw
@@ -107,13 +107,13 @@
 
 # Allow reading all calendars and address books that are direct children of
 # the collection "public" for authenticated users
-#[public-calendars]
+#[public-calendars-addressbooks]
 #user: .+
 #collection: public/[^/]+
 #permissions: r
 
 # Allow access to public calendars and address books via HTTP GET for everyone
-#[public-calendars-restricted]
+#[public-calendars-addressbooks-restricted]
 #user: .*
 #collection: public/[^/]+
 #permissions: i
@@ -129,7 +129,7 @@
 
 # Allow reading all calendars and address books that are direct children of
 # the domain collection
-#[read-domain-calendars]
+#[read-domain-calendars-addressbooks]
 #user: .+@([^@]+)
 #collection: {0}/[^/]+
 #permissions: r


### PR DESCRIPTION
- improve some logging
- improve some default config examples
- add option to replace hardcoded "GROUPS" folder
- add test cases for "GROUPS" feature introduced 2024 for LDAP-only, with 3.8.0 now other authentication schemas can also take use of