### PR TITLE
Add smtp_password_file for email hook

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2119,6 +2119,16 @@ _(>= 3.5.5)_
 
 Password to authenticate with SMTP server.
 Leave empty to disable authentication (e.g. using local mail server).
+Prefer `smtp_password_file` when deploying with a secrets manager.
+
+Default: (unset)
+
+##### smtp_password_file
+
+_(>= 3.5.11)_
+
+Path of a file containing the SMTP server password (for example `/run/secrets/smtp_password`).
+When set, the file contents are used instead of `smtp_password` (trailing newlines are stripped).
 
 Default: (unset)
 

--- a/config
+++ b/config
@@ -509,6 +509,7 @@ Content-Security-Policy = default-src 'self'; object-src 'none'
 #smtp_ssl_verify_mode = REQUIRED
 #smtp_username =
 #smtp_password =
+#smtp_password_file = /run/secrets/smtp_password
 #from_email =
 #mass_email = False
 #new_or_added_to_event_template =

--- a/radicale/config.py
+++ b/radicale/config.py
@@ -688,11 +688,15 @@ DEFAULT_CONFIG_SCHEMA: types.CONFIG_SCHEMA = OrderedDict([
             "type": str}),
         ("smtp_password", {
             "value": "",
-            "help": "SMTP server password",
+            "help": "SMTP server password (prefer smtp_password_file for secrets)",
+            "type": str}),
+        ("smtp_password_file", {
+            "value": "",
+            "help": "Path of the file containing the SMTP server password",
             "type": str}),
         ("from_email", {
             "value": "",
-            "help": "SMTP server password",
+            "help": "Email address to use as sender in email notifications",
             "type": str}),
         ("mass_email", {
             "value": "False",

--- a/radicale/hook/email/__init__.py
+++ b/radicale/hook/email/__init__.py
@@ -61,6 +61,10 @@ PLUGIN_CONFIG_SCHEMA = {
             "value": "",
             "type": str
         },
+        "smtp_password_file": {
+            "value": "",
+            "type": str
+        },
         "from_email": {
             "value": "",
             "type": str
@@ -914,13 +918,18 @@ def _read_event(vobject_data: str) -> EmailEvent:
 class Hook(BaseHook):
     def __init__(self, configuration):
         super().__init__(configuration)
+        smtp_password = self.configuration.get("hook", "smtp_password")
+        smtp_password_file = self.configuration.get("hook", "smtp_password_file")
+        if smtp_password_file:
+            with open(smtp_password_file, "r", encoding="utf-8") as file:
+                smtp_password = file.read().rstrip("\n")
         self.email_config = EmailConfig(
             host=self.configuration.get("hook", "smtp_server"),
             port=self.configuration.get("hook", "smtp_port"),
             security=self.configuration.get("hook", "smtp_security"),
             ssl_verify_mode=self.configuration.get("hook", "smtp_ssl_verify_mode"),
             username=self.configuration.get("hook", "smtp_username"),
-            password=self.configuration.get("hook", "smtp_password"),
+            password=smtp_password,
             from_email=self.configuration.get("hook", "from_email"),
             send_mass_emails=self.configuration.get("hook", "mass_email"),
             dryrun=self.configuration.get("hook", "dryrun"),

--- a/radicale/tests/test_hook_email.py
+++ b/radicale/tests/test_hook_email.py
@@ -262,3 +262,20 @@ permissions: RrWw""")
         # Should NOT have a log saying that no email is sent (email won't actually be sent due to dryrun)
         assert len([log for log in logs if "New event detected, sending notifications to all attendees: event1" in log]) == 1
         assert len([log for log in logs if "Hello everyone" in log]) == 0
+
+    def test_smtp_password_file(self, tmp_path) -> None:
+        from radicale.hook.email import Hook
+
+        secret = tmp_path / "smtp_password"
+        secret.write_text("file-secret\n", encoding="utf-8")
+        self.configure({
+            "hook": {
+                "type": "email",
+                "smtp_server": "localhost",
+                "smtp_password": "inline-secret",
+                "smtp_password_file": str(secret),
+                "dryrun": "True",
+            }
+        })
+        hook = Hook(self.configuration)
+        assert hook.email_config.password == "file-secret"


### PR DESCRIPTION
Read SMTP password from a file (secrets managers). Fixes #1891.