### PR TITLE
Clarify storage Permission denied errors

### DIFF
--- a/radicale/storage/multifilesystem/__init__.py
+++ b/radicale/storage/multifilesystem/__init__.py
@@ -203,7 +203,14 @@ class Storage(
                 if self._use_mtime_and_size_for_item_cache is False:
                     logger.info("Storage cache using mtime and size for 'item' may be an option in case of performance issues")
         except PermissionError as e:
-            logger.error("Directory permissions: %s / Effective user: %s", pathutils.path_permissions_as_string(self._get_collection_root_folder()), utils.user_groups_as_string())
+            logger.error(
+                "Permission denied while accessing storage path %r. "
+                "Check that [storage] filesystem_folder matches a writable Docker/volume mount "
+                "and is owned by the radicale user. Directory permissions: %s / Effective user: %s",
+                self._get_collection_root_folder(),
+                pathutils.path_permissions_as_string(self._get_collection_root_folder()),
+                utils.user_groups_as_string(),
+            )
             raise e
         except Exception:
             logger.warning("Storage item mtime resolution test result not successful")

--- a/radicale/storage/multifilesystem/base.py
+++ b/radicale/storage/multifilesystem/base.py
@@ -174,7 +174,14 @@ class StorageBase(storage.BaseStorage):
         try:
             os.makedirs(filesystem_path, exist_ok=True)
         except PermissionError as e:
-            logger.error("Directory permissions: %s / Effective user: %s", pathutils.path_permissions_as_string(parent_filesystem_path), utils.user_groups_as_string())
+            logger.error(
+                "Cannot create storage path %r (Permission denied). "
+                "Check that [storage] filesystem_folder matches a writable Docker/volume mount "
+                "and is owned by the radicale user. Parent permissions: %s / Effective user: %s",
+                filesystem_path,
+                pathutils.path_permissions_as_string(parent_filesystem_path),
+                utils.user_groups_as_string(),
+            )
             raise e
         except Exception:
             raise


### PR DESCRIPTION
Log the failing path and remind to check filesystem_folder vs mounts. Fixes #2163.