### PR TITLE
Dockerfile: install build dependencies correctly and support source builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG VERSION=master
 # Optional dependencies (e.g. bcrypt or ldap)
 ARG DEPENDENCIES=bcrypt
 
-RUN apk add --no-cache --virtual gcc libffi-dev musl-dev \
+RUN apk add --no-cache --virtual .build-deps gcc libffi-dev musl-dev rust cargo \
     && python -m venv /app/venv \
     && /app/venv/bin/pip install --no-cache-dir "Radicale[${DEPENDENCIES}] @ https://github.com/Kozea/Radicale/archive/${VERSION}.tar.gz"
 


### PR DESCRIPTION
## Problem

The builder stage passes `gcc` as the argument to `--virtual`, which names the virtual package rather than adding it to the install list:

```dockerfile
RUN apk add --no-cache --virtual gcc libffi-dev musl-dev \
```

apk creates a meta-package called `gcc` containing only `libffi-dev` and `musl-dev`, and the C compiler is never installed. It is visible in the build output:

```
(5/5) Installing gcc (20260826.214227)
```

That is the placeholder, not the compiler.

This stays invisible on `linux/amd64` and `linux/arm64` — the only platforms built in `docker-publish.yml` — because every dependency resolves to a prebuilt musllinux wheel and nothing is ever compiled. CI is green and the published images are fine.

On platforms without wheels the stage fails. `bcrypt` is the default value of `DEPENDENCIES` and ships musllinux wheels for `x86_64` and `aarch64` only, so on `linux/arm/v7` pip builds it from source:

```
running build_rust
error: can't find Rust compiler
This package requires Rust >=1.64.0.
ERROR: Failed building wheel for bcrypt
```

Reproduce with:

```
docker buildx build --platform linux/arm/v7 -f Dockerfile .
```

## Fix

Rename the virtual package to `.build-deps` so `gcc` is actually installed, and add `rust` and `cargo` so Rust-based extensions can be compiled where no wheel is published.

Only the builder stage is touched. It is discarded once `/app/venv` is copied, so **the published image is unchanged in size** — the cost is a few seconds of `apk add` at build time on platforms that do not need it.

## Verification

- `linux/amd64` — builds, no regression, `radicale --version` OK.
- `linux/arm/v7` — builds (previously failed), container starts and serves requests:

```
[INFO] Listening on '[::]:5232'
[INFO] Radicale server ready
[INFO] GET response status for '/' in 0.011 seconds plain 19 bytes: 302 Found
```

Runtime check inside the armv7 image:

```
radicale 3.7.8
bcrypt 5.0.0
arch armv7l
```

## Notes

The first half of this (the `--virtual` misuse) is a bug regardless of architecture — any source build needing a C compiler currently fails silently.

The second half (`rust cargo`) is what makes armv7 viable. If you would rather not pay the `apk add` cost on the platforms you publish, it can be made conditional instead:

```dockerfile
ARG TARGETPLATFORM
RUN apk add --no-cache --virtual .build-deps gcc libffi-dev musl-dev \
    && if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then apk add --no-cache rust cargo; fi \
    && ...
```

Happy to switch to that, or to drop the `rust`/`cargo` part entirely and keep only the `--virtual` fix, whichever you prefer. Also happy to add `linux/arm/v7` to the `platforms` list in `docker-publish.yml` in a follow-up if that is of interest.