### PR TITLE
docker-publish: build and publish linux/arm/v7 images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64
+          platforms: arm64,arm
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -75,4 +75,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
Follow-up to #2214, as requested by @kalsi-avneet.

Adds `linux/arm/v7` to the published platform list, so 32-bit ARM boards (Raspberry Pi 2/3, Pi Zero 2 W and other armhf hardware) get an official image instead of having to build one locally.

## Changes

```diff
-          platforms: arm64
+          platforms: arm64,arm
@@
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
```

The QEMU step needs `arm` registered alongside `arm64`. Without it the armv7 leg fails immediately, before any layer is built:

```
exec /bin/sh: exec format error
```

## ⚠️ Depends on #2214 — please merge that first

Merging this ahead of #2214 will break the nightly build.

This workflow sets `DEPENDENCIES=bcrypt,argon2,ldap`, which is a wider set than the Dockerfile default. On armv7 there are no prebuilt musllinux wheels for the compiled ones, so three packages are built from source:

| package | needs | build time |
|---|---|---|
| `argon2-cffi-bindings` | C compiler | 9s |
| `cffi` | C compiler | 31s |
| `bcrypt` | Rust | 134s |

`ldap` resolves to `ldap3`, which is pure Python and needs nothing.

All three fail on current `master`: `gcc` is never installed because of the `--virtual` misuse, and there is no Rust toolchain. #2214 fixes both. Worth noting this makes that PR's impact broader than armv7 alone — the missing compiler would equally break `argon2` on any platform without a wheel.

## Verification

Built locally under QEMU with the exact build arguments this workflow uses:

```
docker buildx build --platform linux/arm/v7 \
  --build-arg DEPENDENCIES=bcrypt,argon2,ldap \
  --build-arg VERSION=master .
```

Builder stage completes in ~286s. The resulting image:

```
radicale 3.8.0.dev0
bcrypt   5.0.0
argon2   25.1.0
ldap3    2.9.1
arch     armv7l
```

and serves requests — `Radicale server ready`, `302` on `/`.

## Cost, so it is not a surprise

The armv7 leg is fully emulated and recompiles those three extensions on every run, so expect it to dominate job runtime — ~286s on my machine, likely longer on GitHub runners. Since this workflow also runs nightly on a cron, that cost is paid every day.

If that is not acceptable, reasonable alternatives are to add a build cache, or to restrict armv7 to `release` events and keep the nightly on amd64/arm64. Happy to rework it either way — just say which you prefer.