### PR TITLE
Fix public token share issues

### DIFF
--- a/radicale/sharing/__init__.py
+++ b/radicale/sharing/__init__.py
@@ -601,7 +601,7 @@ class BaseSharing:
         if self.sharing_collection_by_token:
             logger.trace("sharing/token/resolver: check path: %r", path)
             if path.startswith("/.token/"):
-                pattern = re.compile('^(/\\.token/' + TOKEN_PATTERN_V1 + '/)$')
+                pattern = re.compile('^(/.token/' + TOKEN_PATTERN_V1 + '/)')
                 match = pattern.match(path)
                 if not match:
                     logger.trace("sharing/token/resolver: unsupported token: %r", path)

--- a/radicale/sharing/__init__.py
+++ b/radicale/sharing/__init__.py
@@ -18,6 +18,7 @@
 import base64
 import io
 import json
+import posixpath
 import re
 import socket
 import uuid
@@ -621,6 +622,10 @@ class BaseSharing:
                     if result['EnabledByOwner'] is not True:
                         logger.info("sharing/%s: resolved path %r->%r, User=%r not enabled by owner", "token", path, result['PathMapped'], result['Owner'])
                         return {'error': 'token-not-enabled'}
+
+                    path_suffix = path.removeprefix(match[1])
+                    if path_suffix:
+                        result['PathMapped'] = posixpath.join(result['PathMapped'], path_suffix)
 
                     logger.info("sharing/%s: resolved %r->%r, User=%r, Permissions=%r Conversion=%r", "token", path, result['PathMapped'], result['Owner'], result['Permissions'], result['Conversion'])
                     return result

--- a/radicale/tests/test_sharing.py
+++ b/radicale/tests/test_sharing.py
@@ -901,12 +901,19 @@ class TestSharingApiSanity(BaseTest):
             _, headers, answer = self._sharing_api_form("token", "enable", check=200, login="owner:ownerpw", form_array=form_array)
             assert "Status='success'" in answer
 
+            logging.info("\n*** PUT item using token")
+            event2 = get_file_content("event2.ics")
+            self.put(token + "event2.ics", event2, check=201,
+                     HTTP_IF_NONE_MATCH="*",
+                     content_type="text/calendar; charset=utf-8")
+
             logging.info("\n*** fetch collection using invalid token")
             _, headers, answer = self.request("GET", "/.token/v1/invalidtoken/", check=403)
 
             logging.info("\n*** fetch collection using token")
             _, headers, answer = self.request("GET", token, check=200)
             assert "UID:event" in answer
+            assert "UID:event2" in answer
 
             logging.info("\n*** disable token (form->text)")
             form_array = ["PathOrToken=" + token]


### PR DESCRIPTION
Fixes the issue #2215 by removing the end-of-line selector to the regex check for supported tokens (allowing the calendar path to pass through), and by adding back the calendar path after the token resolver (prevents an issue that popped up after the first fix, where the suffix is missing, and thus it tries to overwrite the calendar and throws a HTTP_IF_NOT_MATCHED error)

I added a test case to PUT an event in a token-shared calendar.